### PR TITLE
feat: support classical rule-providers in clash importer

### DIFF
--- a/examples/ui/all-groups-demo.yaml
+++ b/examples/ui/all-groups-demo.yaml
@@ -1,0 +1,55 @@
+id: ui-all-groups-demo
+net:
+  local:
+    type: local
+  direct-a:
+    type: alias
+    net: local
+  direct-b:
+    type: alias
+    net: local
+  direct-c:
+    type: alias
+    net: local
+  manual-group:
+    type: select
+    selected: direct-a
+    list:
+      - direct-a
+      - direct-b
+      - direct-c
+  auto-url-group:
+    type: url-test
+    selected: direct-a
+    list:
+      - direct-a
+      - direct-b
+      - direct-c
+    url: http://www.gstatic.com/generate_204
+    interval: 300
+    tolerance: 50
+  auto-fallback-group:
+    type: fallback
+    selected: direct-a
+    list:
+      - direct-a
+      - direct-b
+      - direct-c
+    url: http://www.gstatic.com/generate_204
+    interval: 300
+server:
+  mixed-select:
+    type: http+socks5
+    bind: 127.0.0.1:12080
+    net: manual-group
+    listen: local
+  mixed-url-test:
+    type: http+socks5
+    bind: 127.0.0.1:12081
+    net: auto-url-group
+    listen: local
+  mixed-fallback:
+    type: http+socks5
+    bind: 127.0.0.1:12082
+    net: auto-fallback-group
+    listen: local

--- a/examples/ui/fallback-demo.yaml
+++ b/examples/ui/fallback-demo.yaml
@@ -1,0 +1,24 @@
+id: ui-auto-fallback-demo
+net:
+  local:
+    type: local
+  direct-a:
+    type: alias
+    net: local
+  direct-b:
+    type: alias
+    net: local
+  auto-fallback-group:
+    type: fallback
+    selected: direct-a
+    list:
+      - direct-a
+      - direct-b
+    url: http://www.gstatic.com/generate_204
+    interval: 300
+server:
+  mixed:
+    type: http+socks5
+    bind: 127.0.0.1:11082
+    net: auto-fallback-group
+    listen: local

--- a/examples/ui/select-demo.yaml
+++ b/examples/ui/select-demo.yaml
@@ -1,0 +1,22 @@
+id: ui-select-demo
+net:
+  local:
+    type: local
+  direct-a:
+    type: alias
+    net: local
+  direct-b:
+    type: alias
+    net: local
+  manual-group:
+    type: select
+    selected: direct-a
+    list:
+      - direct-a
+      - direct-b
+server:
+  mixed:
+    type: http+socks5
+    bind: 127.0.0.1:11080
+    net: manual-group
+    listen: local

--- a/examples/ui/url-test-demo.yaml
+++ b/examples/ui/url-test-demo.yaml
@@ -1,0 +1,25 @@
+id: ui-auto-url-test-demo
+net:
+  local:
+    type: local
+  direct-a:
+    type: alias
+    net: local
+  direct-b:
+    type: alias
+    net: local
+  auto-url-group:
+    type: url-test
+    selected: direct-a
+    list:
+      - direct-a
+      - direct-b
+    url: http://www.gstatic.com/generate_204
+    interval: 300
+    tolerance: 50
+server:
+  mixed:
+    type: http+socks5
+    bind: 127.0.0.1:11081
+    net: auto-url-group
+    listen: local

--- a/src/auto_select.rs
+++ b/src/auto_select.rs
@@ -8,6 +8,8 @@ use tokio::{
 
 pub(crate) const DEFAULT_TEST_URL: &str = "http://www.gstatic.com/generate_204";
 const DEFAULT_TIMEOUT_MS: u64 = 5_000;
+pub(crate) const DEFAULT_TEST_TIMEOUT_MS: u64 = 5_000;
+pub(crate) const DEFAULT_MAX_FAILED_TIMES: u32 = 5;
 
 pub(crate) fn default_test_url() -> String {
     DEFAULT_TEST_URL.to_string()
@@ -23,6 +25,8 @@ pub(crate) enum AutoSelectMode {
 struct AutoSelectState {
     selected_idx: usize,
     last_checked_at: Option<Instant>,
+    failed_times: u32,
+    failed_time: Option<Instant>,
 }
 
 pub(crate) struct AutoSelectCore {
@@ -31,6 +35,8 @@ pub(crate) struct AutoSelectCore {
     test_url: Url,
     interval: Duration,
     tolerance: u64,
+    test_timeout: Duration,
+    max_failed_times: u32,
     state: Mutex<AutoSelectState>,
 }
 
@@ -42,6 +48,8 @@ impl AutoSelectCore {
         url: String,
         interval: u64,
         tolerance: u64,
+        test_timeout: u64,
+        max_failed_times: u32,
     ) -> rd_interface::Result<Self> {
         if list.is_empty() {
             return Err(Error::other(format!("{mode:?} list is empty")));
@@ -61,9 +69,21 @@ impl AutoSelectCore {
             test_url,
             interval: Duration::from_secs(interval),
             tolerance,
+            test_timeout: Duration::from_millis(if test_timeout == 0 {
+                DEFAULT_TEST_TIMEOUT_MS
+            } else {
+                test_timeout
+            }),
+            max_failed_times: if max_failed_times == 0 {
+                DEFAULT_MAX_FAILED_TIMES
+            } else {
+                max_failed_times
+            },
             state: Mutex::new(AutoSelectState {
                 selected_idx,
                 last_checked_at: None,
+                failed_times: 0,
+                failed_time: None,
             }),
         })
     }
@@ -94,6 +114,40 @@ impl AutoSelectCore {
 
     pub(crate) async fn current_net(&self) -> rd_interface::Result<Net> {
         Ok(self.list[self.current_index().await?].clone())
+    }
+
+    pub(crate) async fn on_operation_success(&self) {
+        let mut state = self.state.lock().await;
+        state.failed_times = 0;
+        state.failed_time = None;
+    }
+
+    pub(crate) async fn on_operation_failure(&self, err: &rd_interface::Error) {
+        let mut state = self.state.lock().await;
+        let err = err.to_string();
+        if err.contains("connection refused") {
+            state.last_checked_at = None;
+            state.failed_times = 0;
+            state.failed_time = None;
+            return;
+        }
+
+        let now = Instant::now();
+        match state.failed_time {
+            Some(first_failed_at) if first_failed_at.elapsed() <= self.test_timeout => {
+                state.failed_times += 1;
+            }
+            _ => {
+                state.failed_times = 1;
+                state.failed_time = Some(now);
+            }
+        }
+
+        if state.failed_times >= self.max_failed_times {
+            state.last_checked_at = None;
+            state.failed_times = 0;
+            state.failed_time = None;
+        }
     }
 
     async fn pick_fallback_index(&self, current_idx: usize) -> rd_interface::Result<usize> {

--- a/src/auto_select.rs
+++ b/src/auto_select.rs
@@ -1,0 +1,184 @@
+use rd_interface::{registry::NetRef, Context, Error, IntoAddress, Net};
+use reqwest::Url;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    sync::Mutex,
+    time::{timeout, Duration, Instant},
+};
+
+pub(crate) const DEFAULT_TEST_URL: &str = "http://www.gstatic.com/generate_204";
+const DEFAULT_TIMEOUT_MS: u64 = 5_000;
+
+pub(crate) fn default_test_url() -> String {
+    DEFAULT_TEST_URL.to_string()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AutoSelectMode {
+    UrlTest,
+    Fallback,
+}
+
+#[derive(Debug)]
+struct AutoSelectState {
+    selected_idx: usize,
+    last_checked_at: Option<Instant>,
+}
+
+pub(crate) struct AutoSelectCore {
+    mode: AutoSelectMode,
+    list: Vec<Net>,
+    test_url: Url,
+    interval: Duration,
+    tolerance: u64,
+    state: Mutex<AutoSelectState>,
+}
+
+impl AutoSelectCore {
+    pub(crate) fn new(
+        mode: AutoSelectMode,
+        selected: NetRef,
+        list: Vec<NetRef>,
+        url: String,
+        interval: u64,
+        tolerance: u64,
+    ) -> rd_interface::Result<Self> {
+        if list.is_empty() {
+            return Err(Error::other(format!("{mode:?} list is empty")));
+        }
+
+        let selected_idx = list
+            .iter()
+            .position(|item| item.represent() == selected.represent())
+            .unwrap_or(0);
+        let nets = list.into_iter().map(|item| item.value_cloned()).collect();
+        let test_url = Url::parse(&url)
+            .map_err(|err| Error::other(format!("invalid auto-select url {url}: {err}")))?;
+
+        Ok(Self {
+            mode,
+            list: nets,
+            test_url,
+            interval: Duration::from_secs(interval),
+            tolerance,
+            state: Mutex::new(AutoSelectState {
+                selected_idx,
+                last_checked_at: None,
+            }),
+        })
+    }
+
+    fn should_refresh(&self, state: &AutoSelectState) -> bool {
+        match state.last_checked_at {
+            None => true,
+            Some(_) if self.interval.is_zero() => false,
+            Some(last_checked_at) => last_checked_at.elapsed() >= self.interval,
+        }
+    }
+
+    pub(crate) async fn current_index(&self) -> rd_interface::Result<usize> {
+        let mut state = self.state.lock().await;
+        if !self.should_refresh(&state) {
+            return Ok(state.selected_idx);
+        }
+
+        let current_idx = state.selected_idx.min(self.list.len().saturating_sub(1));
+        let next_idx = match self.mode {
+            AutoSelectMode::UrlTest => self.pick_url_test_index(current_idx).await?,
+            AutoSelectMode::Fallback => self.pick_fallback_index(current_idx).await?,
+        };
+        state.selected_idx = next_idx;
+        state.last_checked_at = Some(Instant::now());
+        Ok(next_idx)
+    }
+
+    pub(crate) async fn current_net(&self) -> rd_interface::Result<Net> {
+        Ok(self.list[self.current_index().await?].clone())
+    }
+
+    async fn pick_fallback_index(&self, current_idx: usize) -> rd_interface::Result<usize> {
+        for (idx, net) in self.list.iter().enumerate() {
+            if Self::probe_delay(net, &self.test_url).await.is_ok() {
+                return Ok(idx);
+            }
+        }
+        Ok(current_idx.min(self.list.len().saturating_sub(1)))
+    }
+
+    async fn pick_url_test_index(&self, current_idx: usize) -> rd_interface::Result<usize> {
+        let mut best: Option<(usize, u64)> = None;
+        let mut current_delay: Option<u64> = None;
+
+        for (idx, net) in self.list.iter().enumerate() {
+            let Ok(delay) = Self::probe_delay(net, &self.test_url).await else {
+                continue;
+            };
+
+            if idx == current_idx {
+                current_delay = Some(delay);
+            }
+            if best
+                .map(|(_, best_delay)| delay < best_delay)
+                .unwrap_or(true)
+            {
+                best = Some((idx, delay));
+            }
+        }
+
+        match best {
+            Some((best_idx, best_delay)) => {
+                if best_idx == current_idx {
+                    return Ok(best_idx);
+                }
+                if let Some(delay) = current_delay {
+                    if delay <= best_delay.saturating_add(self.tolerance) {
+                        return Ok(current_idx.min(self.list.len().saturating_sub(1)));
+                    }
+                }
+                Ok(best_idx)
+            }
+            None => Ok(current_idx.min(self.list.len().saturating_sub(1))),
+        }
+    }
+
+    async fn probe_delay(net: &Net, url: &Url) -> rd_interface::Result<u64> {
+        let host = url
+            .host_str()
+            .ok_or_else(|| Error::other(format!("missing host in probe url: {url}")))?;
+        let port = url
+            .port_or_known_default()
+            .ok_or_else(|| Error::other(format!("missing port in probe url: {url}")))?;
+
+        timeout(Duration::from_millis(DEFAULT_TIMEOUT_MS), async {
+            let start = Instant::now();
+            let mut socket = net
+                .tcp_connect(&mut Context::new(), &(host, port).into_address()?)
+                .await?;
+
+            let host_header = match url.port_or_known_default() {
+                Some(p) => format!("{}:{}", host, p),
+                None => host.to_string(),
+            };
+            let mut path_and_query = url.path().to_string();
+            if path_and_query.is_empty() {
+                path_and_query = "/".to_string();
+            }
+            if let Some(query) = url.query() {
+                path_and_query.push('?');
+                path_and_query.push_str(query);
+            }
+            let request = format!(
+                "GET {path} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n",
+                path = path_and_query,
+                host = host_header
+            );
+            socket.write_all(request.as_bytes()).await?;
+            socket.flush().await?;
+
+            let mut one = [0u8; 1];
+            socket.read_exact(&mut one).await?;
+            Ok::<u64, rd_interface::Error>(start.elapsed().as_millis() as u64)
+        })
+        .await?
+    }
+}

--- a/src/config/importer/clash.rs
+++ b/src/config/importer/clash.rs
@@ -106,6 +106,9 @@ struct ProxyGroup {
     #[serde(rename = "type")]
     proxy_group_type: String,
     proxies: Vec<String>,
+    url: Option<String>,
+    interval: Option<u64>,
+    tolerance: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -364,19 +367,25 @@ impl Clash {
                     "list": net_list,
                 }),
             ),
-            "url-test" | "fallback" => {
-                tracing::warn!(
-                    "Unsupported proxy group type: {}, will use select as fallback.",
-                    proxy_group_type
-                );
-                Net::new(
-                    "select",
-                    json!({
-                        "selected": net_list.get(0).cloned().unwrap_or_else(|| "noop".to_string()),
-                        "list": net_list,
-                    }),
-                )
-            }
+            "url-test" => Net::new(
+                "url-test",
+                json!({
+                    "selected": net_list.get(0).cloned().unwrap_or_else(|| "noop".to_string()),
+                    "list": net_list,
+                    "url": p.url.unwrap_or_else(|| "http://www.gstatic.com/generate_204".to_string()),
+                    "interval": p.interval.unwrap_or(300),
+                    "tolerance": p.tolerance.unwrap_or(0),
+                }),
+            ),
+            "fallback" => Net::new(
+                "fallback",
+                json!({
+                    "selected": net_list.get(0).cloned().unwrap_or_else(|| "noop".to_string()),
+                    "list": net_list,
+                    "url": p.url.unwrap_or_else(|| "http://www.gstatic.com/generate_204".to_string()),
+                    "interval": p.interval.unwrap_or(300),
+                }),
+            ),
             "relay" => {
                 let net = net_list.iter().try_fold(
                     Net::new(
@@ -925,6 +934,9 @@ mod tests {
             name: "g".to_string(),
             proxy_group_type: "select".to_string(),
             proxies: vec!["a".to_string(), "b".to_string()],
+            url: None,
+            interval: None,
+            tolerance: None,
         };
         assert_eq!(
             c.proxy_group_to_net(pg_select, &proxy_map)
@@ -937,18 +949,42 @@ mod tests {
             name: "g".to_string(),
             proxy_group_type: "url-test".to_string(),
             proxies: vec!["a".to_string()],
+            url: Some("http://example.com/test".to_string()),
+            interval: Some(42),
+            tolerance: Some(7),
         };
+        let net = c.proxy_group_to_net(pg_urltest, &proxy_map).unwrap();
+        assert_eq!(net.net_type, "url-test");
         assert_eq!(
-            c.proxy_group_to_net(pg_urltest, &proxy_map)
-                .unwrap()
-                .net_type,
-            "select"
+            net.opt.get("url").and_then(|v| v.as_str()),
+            Some("http://example.com/test")
         );
+        assert_eq!(net.opt.get("interval").and_then(|v| v.as_u64()), Some(42));
+        assert_eq!(net.opt.get("tolerance").and_then(|v| v.as_u64()), Some(7));
+
+        let pg_fallback = ProxyGroup {
+            name: "g".to_string(),
+            proxy_group_type: "fallback".to_string(),
+            proxies: vec!["a".to_string()],
+            url: Some("http://example.com/fallback".to_string()),
+            interval: Some(24),
+            tolerance: None,
+        };
+        let net = c.proxy_group_to_net(pg_fallback, &proxy_map).unwrap();
+        assert_eq!(net.net_type, "fallback");
+        assert_eq!(
+            net.opt.get("url").and_then(|v| v.as_str()),
+            Some("http://example.com/fallback")
+        );
+        assert_eq!(net.opt.get("interval").and_then(|v| v.as_u64()), Some(24));
 
         let pg_relay_missing_proxy = ProxyGroup {
             name: "g".to_string(),
             proxy_group_type: "relay".to_string(),
             proxies: vec!["b".to_string()],
+            url: None,
+            interval: None,
+            tolerance: None,
         };
         assert!(c
             .proxy_group_to_net(pg_relay_missing_proxy, &proxy_map)
@@ -958,6 +994,9 @@ mod tests {
             name: "g".to_string(),
             proxy_group_type: "bad".to_string(),
             proxies: vec!["a".to_string()],
+            url: None,
+            interval: None,
+            tolerance: None,
         };
         assert!(c.proxy_group_to_net(pg_bad, &proxy_map).is_err());
     }

--- a/src/config/importer/clash.rs
+++ b/src/config/importer/clash.rs
@@ -109,6 +109,10 @@ struct ProxyGroup {
     url: Option<String>,
     interval: Option<u64>,
     tolerance: Option<u64>,
+    #[serde(rename = "test-timeout")]
+    test_timeout: Option<u64>,
+    #[serde(rename = "max-failed-times")]
+    max_failed_times: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -375,6 +379,8 @@ impl Clash {
                     "url": p.url.unwrap_or_else(|| "http://www.gstatic.com/generate_204".to_string()),
                     "interval": p.interval.unwrap_or(300),
                     "tolerance": p.tolerance.unwrap_or(0),
+                    "test_timeout": p.test_timeout.unwrap_or(5000),
+                    "max_failed_times": p.max_failed_times.unwrap_or(5),
                 }),
             ),
             "fallback" => Net::new(
@@ -384,6 +390,8 @@ impl Clash {
                     "list": net_list,
                     "url": p.url.unwrap_or_else(|| "http://www.gstatic.com/generate_204".to_string()),
                     "interval": p.interval.unwrap_or(300),
+                    "test_timeout": p.test_timeout.unwrap_or(5000),
+                    "max_failed_times": p.max_failed_times.unwrap_or(5),
                 }),
             ),
             "relay" => {
@@ -937,6 +945,8 @@ mod tests {
             url: None,
             interval: None,
             tolerance: None,
+            test_timeout: None,
+            max_failed_times: None,
         };
         assert_eq!(
             c.proxy_group_to_net(pg_select, &proxy_map)
@@ -952,6 +962,8 @@ mod tests {
             url: Some("http://example.com/test".to_string()),
             interval: Some(42),
             tolerance: Some(7),
+            test_timeout: Some(1234),
+            max_failed_times: Some(3),
         };
         let net = c.proxy_group_to_net(pg_urltest, &proxy_map).unwrap();
         assert_eq!(net.net_type, "url-test");
@@ -961,6 +973,14 @@ mod tests {
         );
         assert_eq!(net.opt.get("interval").and_then(|v| v.as_u64()), Some(42));
         assert_eq!(net.opt.get("tolerance").and_then(|v| v.as_u64()), Some(7));
+        assert_eq!(
+            net.opt.get("test_timeout").and_then(|v| v.as_u64()),
+            Some(1234)
+        );
+        assert_eq!(
+            net.opt.get("max_failed_times").and_then(|v| v.as_u64()),
+            Some(3)
+        );
 
         let pg_fallback = ProxyGroup {
             name: "g".to_string(),
@@ -969,6 +989,8 @@ mod tests {
             url: Some("http://example.com/fallback".to_string()),
             interval: Some(24),
             tolerance: None,
+            test_timeout: Some(2345),
+            max_failed_times: Some(4),
         };
         let net = c.proxy_group_to_net(pg_fallback, &proxy_map).unwrap();
         assert_eq!(net.net_type, "fallback");
@@ -977,6 +999,14 @@ mod tests {
             Some("http://example.com/fallback")
         );
         assert_eq!(net.opt.get("interval").and_then(|v| v.as_u64()), Some(24));
+        assert_eq!(
+            net.opt.get("test_timeout").and_then(|v| v.as_u64()),
+            Some(2345)
+        );
+        assert_eq!(
+            net.opt.get("max_failed_times").and_then(|v| v.as_u64()),
+            Some(4)
+        );
 
         let pg_relay_missing_proxy = ProxyGroup {
             name: "g".to_string(),
@@ -985,6 +1015,8 @@ mod tests {
             url: None,
             interval: None,
             tolerance: None,
+            test_timeout: None,
+            max_failed_times: None,
         };
         assert!(c
             .proxy_group_to_net(pg_relay_missing_proxy, &proxy_map)
@@ -997,6 +1029,8 @@ mod tests {
             url: None,
             interval: None,
             tolerance: None,
+            test_timeout: None,
+            max_failed_times: None,
         };
         assert!(c.proxy_group_to_net(pg_bad, &proxy_map).is_err());
     }

--- a/src/config/importer/clash.rs
+++ b/src/config/importer/clash.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use futures::{stream, StreamExt};
+use futures::{future::BoxFuture, stream, StreamExt, TryStreamExt};
 use rabbit_digger::{
     config::{Config, Net},
     rd_std::rule::config::{
@@ -413,108 +413,154 @@ impl Clash {
         cache: &dyn Storage,
         rule_providers: &BTreeMap<String, RuleProvider>,
         oom_lock: &Mutex<()>,
-    ) -> Result<rule_config::RuleItem> {
-        let bad_rule = || anyhow!("Bad rule.");
-        let mut ps = r.split(',');
-        let mut ps_next = || ps.next().ok_or_else(bad_rule);
-        let rule_type = ps_next()?;
-        let item = match rule_type {
-            "DOMAIN-SUFFIX" | "DOMAIN-KEYWORD" | "DOMAIN" => {
-                let domain = ps_next()?.to_string();
-                let target = NetRef::new(self.get_target(ps_next()?)?.into());
-                let method = match rule_type {
-                    "DOMAIN-SUFFIX" => DomainMatcherMethod::Suffix,
-                    "DOMAIN-KEYWORD" => DomainMatcherMethod::Keyword,
-                    "DOMAIN" => DomainMatcherMethod::Match,
-                    _ => return Err(bad_rule()),
-                };
-                rule_config::RuleItem {
-                    target,
-                    matcher: Matcher::Domain(DomainMatcher {
-                        method,
-                        domain: domain.into(),
-                    }),
-                }
-            }
-            "IP-CIDR" | "IP-CIDR6" => {
-                let ip_cidr = ps_next()?.to_string();
-                let target = NetRef::new(self.get_target(ps_next()?)?.into());
-                rule_config::RuleItem {
-                    target,
-                    matcher: Matcher::IpCidr(IpCidrMatcher {
-                        ipcidr: IpCidr::from_str(&ip_cidr)?.into(),
-                    }),
-                }
-            }
-            "SRC-IP-CIDR" => {
-                let ip_cidr = ps_next()?.to_string();
-                let target = NetRef::new(self.get_target(ps_next()?)?.into());
-                rule_config::RuleItem {
-                    target,
-                    matcher: Matcher::SrcIpCidr(SrcIpCidrMatcher {
-                        ipcidr: IpCidr::from_str(&ip_cidr)?.into(),
-                    }),
-                }
-            }
-            "MATCH" => {
-                let target = NetRef::new(self.get_target(ps_next()?)?.into());
-                rule_config::RuleItem {
-                    target,
-                    matcher: Matcher::Any(AnyMatcher {}),
-                }
-            }
-            "GEOIP" => {
-                let region = ps_next()?.to_string();
-                let target = NetRef::new(self.get_target(ps_next()?)?.into());
-                rule_config::RuleItem {
-                    target,
-                    matcher: Matcher::GeoIp(GeoIpMatcher { country: region }),
-                }
-            }
-            "RULE-SET" => {
-                let set = ps_next()?.to_string();
-                let target = NetRef::new(self.get_target(ps_next()?)?.into());
-                let rule_provider = rule_providers.get(&set).ok_or_else(bad_rule)?;
+    ) -> Result<Vec<rule_config::RuleItem>> {
+        self.rule_to_rule_with_target(r, None, cache, rule_providers, oom_lock)
+            .await
+    }
 
-                let source = match rule_provider.rule_type.as_ref() {
-                    "http" => ImportSource::new_poll(
-                        rule_provider.url.to_string(),
-                        Some(rule_provider.interval),
-                    ),
-                    "file" => ImportSource::new_path(PathBuf::from(rule_provider.path.to_string())),
-                    _ => return Err(bad_rule()),
-                };
-
-                let source_str = source.get_content(cache).await?;
-                let _guard = oom_lock.lock().await;
-
-                let RuleSet { payload } = serde_yaml::from_str(&source_str)?;
-                match rule_provider.behavior.as_ref() {
-                    "domain" => rule_config::RuleItem {
-                        target: target.clone(),
+    fn rule_to_rule_with_target<'a>(
+        &'a self,
+        r: String,
+        inherited_target: Option<NetRef>,
+        cache: &'a dyn Storage,
+        rule_providers: &'a BTreeMap<String, RuleProvider>,
+        oom_lock: &'a Mutex<()>,
+    ) -> BoxFuture<'a, Result<Vec<rule_config::RuleItem>>> {
+        Box::pin(async move {
+            let bad_rule = || anyhow!("Bad rule.");
+            let mut ps = r.split(',');
+            let mut ps_next = || ps.next().ok_or_else(bad_rule);
+            let rule_type = ps_next()?;
+            let items = match rule_type {
+                "DOMAIN-SUFFIX" | "DOMAIN-KEYWORD" | "DOMAIN" => {
+                    let domain = ps_next()?.to_string();
+                    let target = match inherited_target.clone() {
+                        Some(target) => target,
+                        None => NetRef::new(self.get_target(ps_next()?)?.into()),
+                    };
+                    let method = match rule_type {
+                        "DOMAIN-SUFFIX" => DomainMatcherMethod::Suffix,
+                        "DOMAIN-KEYWORD" => DomainMatcherMethod::Keyword,
+                        "DOMAIN" => DomainMatcherMethod::Match,
+                        _ => return Err(bad_rule()),
+                    };
+                    vec![rule_config::RuleItem {
+                        target,
                         matcher: Matcher::Domain(DomainMatcher {
-                            method: DomainMatcherMethod::Match,
-                            domain: payload.into(),
+                            method,
+                            domain: domain.into(),
                         }),
-                    },
-                    "ipcidr" => rule_config::RuleItem {
-                        target: target.clone(),
-                        matcher: Matcher::IpCidr(IpCidrMatcher {
-                            ipcidr: payload
-                                .into_iter()
-                                .map(|i| IpCidr::from_str(&i))
-                                .collect::<rd_interface::Result<Vec<_>>>()?
-                                .into(),
-                        }),
-                    },
-                    // TODO: support classical behavior
-                    _ => return Err(bad_rule()),
+                    }]
                 }
-            }
-            _ => return Err(anyhow!("Rule prefix {} is not supported", rule_type)),
-        };
+                "IP-CIDR" | "IP-CIDR6" => {
+                    let ip_cidr = ps_next()?.to_string();
+                    let target = match inherited_target.clone() {
+                        Some(target) => target,
+                        None => NetRef::new(self.get_target(ps_next()?)?.into()),
+                    };
+                    vec![rule_config::RuleItem {
+                        target,
+                        matcher: Matcher::IpCidr(IpCidrMatcher {
+                            ipcidr: IpCidr::from_str(&ip_cidr)?.into(),
+                        }),
+                    }]
+                }
+                "SRC-IP-CIDR" => {
+                    let ip_cidr = ps_next()?.to_string();
+                    let target = match inherited_target.clone() {
+                        Some(target) => target,
+                        None => NetRef::new(self.get_target(ps_next()?)?.into()),
+                    };
+                    vec![rule_config::RuleItem {
+                        target,
+                        matcher: Matcher::SrcIpCidr(SrcIpCidrMatcher {
+                            ipcidr: IpCidr::from_str(&ip_cidr)?.into(),
+                        }),
+                    }]
+                }
+                "MATCH" => {
+                    let target = match inherited_target.clone() {
+                        Some(target) => target,
+                        None => NetRef::new(self.get_target(ps_next()?)?.into()),
+                    };
+                    vec![rule_config::RuleItem {
+                        target,
+                        matcher: Matcher::Any(AnyMatcher {}),
+                    }]
+                }
+                "GEOIP" => {
+                    let region = ps_next()?.to_string();
+                    let target = match inherited_target.clone() {
+                        Some(target) => target,
+                        None => NetRef::new(self.get_target(ps_next()?)?.into()),
+                    };
+                    vec![rule_config::RuleItem {
+                        target,
+                        matcher: Matcher::GeoIp(GeoIpMatcher { country: region }),
+                    }]
+                }
+                "RULE-SET" => {
+                    let set = ps_next()?.to_string();
+                    let target = NetRef::new(self.get_target(ps_next()?)?.into());
+                    let rule_provider = rule_providers.get(&set).ok_or_else(bad_rule)?;
 
-        Ok(item)
+                    let source = match rule_provider.rule_type.as_ref() {
+                        "http" => ImportSource::new_poll(
+                            rule_provider.url.to_string(),
+                            Some(rule_provider.interval),
+                        ),
+                        "file" => {
+                            ImportSource::new_path(PathBuf::from(rule_provider.path.to_string()))
+                        }
+                        _ => return Err(bad_rule()),
+                    };
+
+                    let source_str = source.get_content(cache).await?;
+                    let _guard = oom_lock.lock().await;
+
+                    let RuleSet { payload } = serde_yaml::from_str(&source_str)?;
+                    match rule_provider.behavior.as_ref() {
+                        "domain" => vec![rule_config::RuleItem {
+                            target: target.clone(),
+                            matcher: Matcher::Domain(DomainMatcher {
+                                method: DomainMatcherMethod::Match,
+                                domain: payload.into(),
+                            }),
+                        }],
+                        "ipcidr" => vec![rule_config::RuleItem {
+                            target: target.clone(),
+                            matcher: Matcher::IpCidr(IpCidrMatcher {
+                                ipcidr: payload
+                                    .into_iter()
+                                    .map(|i| IpCidr::from_str(&i))
+                                    .collect::<rd_interface::Result<Vec<_>>>()?
+                                    .into(),
+                            }),
+                        }],
+                        "classical" => {
+                            let mut items = Vec::new();
+                            for rule in payload {
+                                items.extend(
+                                    self.rule_to_rule_with_target(
+                                        rule,
+                                        Some(target.clone()),
+                                        cache,
+                                        rule_providers,
+                                        oom_lock,
+                                    )
+                                    .await?,
+                                );
+                            }
+                            items
+                        }
+                        _ => return Err(bad_rule()),
+                    }
+                }
+                _ => return Err(anyhow!("Rule prefix {} is not supported", rule_type)),
+            };
+
+            Ok(items)
+        })
     }
 
     fn proxy_group_name(&self, pg: impl AsRef<str>) -> String {
@@ -588,21 +634,22 @@ impl Importer for Clash {
             let rule = stream::iter(clash_config.rules)
                 .map(|r| self.rule_to_rule(r, cache, &clash_config.rule_providers, &oom_lock))
                 .buffered(10)
-                .flat_map(stream::iter)
-                .fold(
+                .try_fold(
                     Vec::<rule_config::RuleItem>::new(),
-                    |mut state, item| async move {
-                        let mut merged = false;
-                        if let Some(last) = state.last_mut() {
-                            merged = last.merge(&item);
+                    |mut state, items| async move {
+                        for item in items {
+                            let mut merged = false;
+                            if let Some(last) = state.last_mut() {
+                                merged = last.merge(&item);
+                            }
+                            if !merged {
+                                state.push(item);
+                            }
                         }
-                        if !merged {
-                            state.push(item);
-                        }
-                        state
+                        Ok(state)
                     },
                 )
-                .await;
+                .await?;
 
             config
                 .net
@@ -932,7 +979,8 @@ mod tests {
             )
             .await
             .unwrap();
-        match item.matcher {
+        assert_eq!(item.len(), 1);
+        match item.into_iter().next().unwrap().matcher {
             Matcher::Domain(d) => assert!(matches!(d.method, DomainMatcherMethod::Suffix)),
             _ => panic!("unexpected matcher"),
         }
@@ -946,7 +994,11 @@ mod tests {
             )
             .await
             .unwrap();
-        matches!(item.matcher, Matcher::IpCidr(_));
+        assert_eq!(item.len(), 1);
+        assert!(matches!(
+            item.into_iter().next().unwrap().matcher,
+            Matcher::IpCidr(_)
+        ));
 
         let item = c
             .rule_to_rule(
@@ -957,7 +1009,11 @@ mod tests {
             )
             .await
             .unwrap();
-        matches!(item.matcher, Matcher::SrcIpCidr(_));
+        assert_eq!(item.len(), 1);
+        assert!(matches!(
+            item.into_iter().next().unwrap().matcher,
+            Matcher::SrcIpCidr(_)
+        ));
 
         let item = c
             .rule_to_rule(
@@ -968,7 +1024,11 @@ mod tests {
             )
             .await
             .unwrap();
-        matches!(item.matcher, Matcher::Any(_));
+        assert_eq!(item.len(), 1);
+        assert!(matches!(
+            item.into_iter().next().unwrap().matcher,
+            Matcher::Any(_)
+        ));
 
         let item = c
             .rule_to_rule(
@@ -979,7 +1039,11 @@ mod tests {
             )
             .await
             .unwrap();
-        matches!(item.matcher, Matcher::GeoIp(_));
+        assert_eq!(item.len(), 1);
+        assert!(matches!(
+            item.into_iter().next().unwrap().matcher,
+            Matcher::GeoIp(_)
+        ));
 
         let mut rules = BTreeMap::new();
         let mut tmp = NamedTempFile::new().unwrap();
@@ -1006,12 +1070,107 @@ mod tests {
             .await
             .unwrap();
 
-        match item.matcher {
+        assert_eq!(item.len(), 1);
+        match item.into_iter().next().unwrap().matcher {
             Matcher::Domain(d) => {
                 assert!(matches!(d.method, DomainMatcherMethod::Match));
                 assert!(d.domain.len() >= 2);
             }
             _ => panic!("unexpected matcher"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_rule_to_rule_rule_set_classical_inherits_outer_target() {
+        let mut c = base_clash();
+        c.name_map.insert("ProxyA".to_string(), "pA".to_string());
+
+        let cache = crate::storage::MemoryCache::new().await.unwrap();
+        let oom_lock = Mutex::new(());
+
+        let mut rules = BTreeMap::new();
+        let mut tmp = NamedTempFile::new().unwrap();
+        std::io::Write::write_all(
+            &mut tmp,
+            b"payload:\n  - DOMAIN-SUFFIX,example.com\n  - GEOIP,CN\n",
+        )
+        .unwrap();
+
+        rules.insert(
+            "set1".to_string(),
+            RuleProvider {
+                rule_type: "file".to_string(),
+                behavior: "classical".to_string(),
+                url: "".to_string(),
+                path: tmp.path().to_string_lossy().to_string(),
+                interval: 1,
+            },
+        );
+
+        let items = c
+            .rule_to_rule(
+                "RULE-SET,set1,ProxyA".to_string(),
+                &cache,
+                &rules,
+                &oom_lock,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(items.len(), 2);
+        assert!(items.iter().all(|item| item.target.represent() == "pA"));
+        assert!(matches!(items[0].matcher, Matcher::Domain(_)));
+        assert!(matches!(items[1].matcher, Matcher::GeoIp(_)));
+    }
+
+    #[tokio::test]
+    async fn test_process_flattens_classical_rule_set_rules() {
+        let mut clash = base_clash();
+        clash.rule_name = Some("rules".to_string());
+
+        let mut tmp = NamedTempFile::new().unwrap();
+        std::io::Write::write_all(
+            &mut tmp,
+            b"payload:\n  - DOMAIN-SUFFIX,example.com\n  - DOMAIN-SUFFIX,example.org\n",
+        )
+        .unwrap();
+
+        let content = format!(
+            r#"proxies:
+  - name: ProxyA
+    type: direct
+proxy-groups: []
+rules:
+  - RULE-SET,set1,ProxyA
+rule-providers:
+  set1:
+    type: file
+    behavior: classical
+    path: {}
+    url: ""
+    interval: 1
+"#,
+            tmp.path().display()
+        );
+
+        let mut config = Config::default();
+        let cache = crate::storage::MemoryCache::new().await.unwrap();
+        clash.process(&mut config, &content, &cache).await.unwrap();
+
+        let rule_net = config.net.get("rules").unwrap();
+        assert_eq!(rule_net.net_type, "rule");
+
+        let rule = rule_net
+            .opt
+            .get("rule")
+            .and_then(|value| value.as_array())
+            .unwrap();
+        assert_eq!(rule.len(), 1);
+
+        let domains = rule[0]
+            .get("domain")
+            .and_then(|value| value.as_array())
+            .unwrap();
+        assert_eq!(domains.len(), 2);
     }
 }

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -4,7 +4,18 @@ use rd_interface::{
     TcpConnect, TcpListener, TcpStream, UdpBind, UdpSocket,
 };
 
-use crate::auto_select::{default_test_url, AutoSelectCore, AutoSelectMode};
+use crate::auto_select::{
+    default_test_url, AutoSelectCore, AutoSelectMode, DEFAULT_MAX_FAILED_TIMES,
+    DEFAULT_TEST_TIMEOUT_MS,
+};
+
+fn default_test_timeout() -> u64 {
+    DEFAULT_TEST_TIMEOUT_MS
+}
+
+fn default_max_failed_times() -> u32 {
+    DEFAULT_MAX_FAILED_TIMES
+}
 
 #[rd_config]
 #[derive(Debug, Clone)]
@@ -15,6 +26,10 @@ pub struct FallbackNetConfig {
     url: String,
     #[serde(default)]
     interval: u64,
+    #[serde(default = "default_test_timeout")]
+    test_timeout: u64,
+    #[serde(default = "default_max_failed_times")]
+    max_failed_times: u32,
 }
 
 pub struct FallbackNet {
@@ -31,6 +46,8 @@ impl FallbackNet {
                 config.url,
                 config.interval,
                 0,
+                config.test_timeout,
+                config.max_failed_times,
             )?,
         })
     }
@@ -58,28 +75,68 @@ impl INet for FallbackNet {
 #[async_trait]
 impl TcpConnect for FallbackNet {
     async fn tcp_connect(&self, ctx: &mut Context, addr: &Address) -> Result<TcpStream> {
-        self.inner.current_net().await?.tcp_connect(ctx, addr).await
+        let net = self.inner.current_net().await?;
+        match net.tcp_connect(ctx, addr).await {
+            Ok(stream) => {
+                self.inner.on_operation_success().await;
+                Ok(stream)
+            }
+            Err(err) => {
+                self.inner.on_operation_failure(&err).await;
+                Err(err)
+            }
+        }
     }
 }
 
 #[async_trait]
 impl TcpBind for FallbackNet {
     async fn tcp_bind(&self, ctx: &mut Context, addr: &Address) -> Result<TcpListener> {
-        self.inner.current_net().await?.tcp_bind(ctx, addr).await
+        let net = self.inner.current_net().await?;
+        match net.tcp_bind(ctx, addr).await {
+            Ok(listener) => {
+                self.inner.on_operation_success().await;
+                Ok(listener)
+            }
+            Err(err) => {
+                self.inner.on_operation_failure(&err).await;
+                Err(err)
+            }
+        }
     }
 }
 
 #[async_trait]
 impl UdpBind for FallbackNet {
     async fn udp_bind(&self, ctx: &mut Context, addr: &Address) -> Result<UdpSocket> {
-        self.inner.current_net().await?.udp_bind(ctx, addr).await
+        let net = self.inner.current_net().await?;
+        match net.udp_bind(ctx, addr).await {
+            Ok(socket) => {
+                self.inner.on_operation_success().await;
+                Ok(socket)
+            }
+            Err(err) => {
+                self.inner.on_operation_failure(&err).await;
+                Err(err)
+            }
+        }
     }
 }
 
 #[async_trait]
 impl rd_interface::LookupHost for FallbackNet {
     async fn lookup_host(&self, addr: &Address) -> Result<Vec<std::net::SocketAddr>> {
-        self.inner.current_net().await?.lookup_host(addr).await
+        let net = self.inner.current_net().await?;
+        match net.lookup_host(addr).await {
+            Ok(addrs) => {
+                self.inner.on_operation_success().await;
+                Ok(addrs)
+            }
+            Err(err) => {
+                self.inner.on_operation_failure(&err).await;
+                Err(err)
+            }
+        }
     }
 }
 
@@ -100,8 +157,12 @@ pub fn init(registry: &mut Registry) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use rd_interface::{registry::NetRef, IntoDyn};
+    use rd_interface::{registry::NetRef, Error, IntoAddress, IntoDyn};
     use rd_std::tests::{spawn_echo_server, TestNet};
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
     use tokio::time::Duration;
 
     use super::*;
@@ -167,6 +228,129 @@ mod tests {
         NetRef::new_with_value(name.into(), DelayNet::new(inner, delay).into_dyn())
     }
 
+    struct ToggleNet {
+        inner: Net,
+        alive: Arc<AtomicBool>,
+        delay: Duration,
+    }
+
+    impl ToggleNet {
+        fn new(inner: Net, alive: Arc<AtomicBool>, delay: Duration) -> Self {
+            Self {
+                inner,
+                alive,
+                delay,
+            }
+        }
+
+        fn ensure_alive(&self) -> Result<()> {
+            if self.alive.load(Ordering::SeqCst) {
+                Ok(())
+            } else {
+                Err(Error::from(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionRefused,
+                    "connection refused",
+                )))
+            }
+        }
+    }
+
+    #[async_trait]
+    impl rd_interface::TcpConnect for ToggleNet {
+        async fn tcp_connect(&self, ctx: &mut Context, addr: &Address) -> Result<TcpStream> {
+            self.ensure_alive()?;
+            tokio::time::sleep(self.delay).await;
+            self.inner.tcp_connect(ctx, addr).await
+        }
+    }
+
+    #[async_trait]
+    impl rd_interface::TcpBind for ToggleNet {
+        async fn tcp_bind(&self, ctx: &mut Context, addr: &Address) -> Result<TcpListener> {
+            self.ensure_alive()?;
+            self.inner.tcp_bind(ctx, addr).await
+        }
+    }
+
+    #[async_trait]
+    impl rd_interface::UdpBind for ToggleNet {
+        async fn udp_bind(&self, ctx: &mut Context, addr: &Address) -> Result<UdpSocket> {
+            self.ensure_alive()?;
+            self.inner.udp_bind(ctx, addr).await
+        }
+    }
+
+    #[async_trait]
+    impl rd_interface::LookupHost for ToggleNet {
+        async fn lookup_host(&self, addr: &Address) -> Result<Vec<std::net::SocketAddr>> {
+            self.ensure_alive()?;
+            self.inner.lookup_host(addr).await
+        }
+    }
+
+    #[async_trait]
+    impl INet for ToggleNet {
+        fn provide_tcp_connect(&self) -> Option<&dyn rd_interface::TcpConnect> {
+            Some(self)
+        }
+        fn provide_tcp_bind(&self) -> Option<&dyn rd_interface::TcpBind> {
+            Some(self)
+        }
+        fn provide_udp_bind(&self) -> Option<&dyn rd_interface::UdpBind> {
+            Some(self)
+        }
+        fn provide_lookup_host(&self) -> Option<&dyn rd_interface::LookupHost> {
+            Some(self)
+        }
+    }
+
+    fn toggle_net(name: &str, alive: Arc<AtomicBool>, delay: Duration) -> NetRef {
+        let inner = TestNet::new().into_dyn();
+        NetRef::new_with_value(name.into(), ToggleNet::new(inner, alive, delay).into_dyn())
+    }
+
+    #[tokio::test]
+    async fn test_fallback_failed_request_does_not_retry_but_refreshes_health() {
+        let first_alive = Arc::new(AtomicBool::new(true));
+        let second_alive = Arc::new(AtomicBool::new(true));
+        let first = toggle_net("first", first_alive.clone(), Duration::from_millis(5));
+        let second = toggle_net("second", second_alive, Duration::from_millis(10));
+        spawn_echo_server(&first.value_cloned(), "127.0.0.1:18085").await;
+        spawn_echo_server(&second.value_cloned(), "127.0.0.1:18085").await;
+
+        let net = FallbackNet::new(FallbackNetConfig {
+            selected: first.clone(),
+            list: vec![first.clone(), second.clone()],
+            url: "http://127.0.0.1:18085/".to_string(),
+            interval: 60,
+            test_timeout: DEFAULT_TEST_TIMEOUT_MS,
+            max_failed_times: DEFAULT_MAX_FAILED_TIMES,
+        })
+        .unwrap();
+
+        assert_eq!(net.inner.current_index().await.unwrap(), 0);
+        first_alive.store(false, Ordering::SeqCst);
+
+        let mut ctx = Context::new();
+        let err = net
+            .tcp_connect(&mut ctx, &("127.0.0.1", 18085).into_address().unwrap())
+            .await
+            .err()
+            .unwrap();
+        assert!(err.to_string().contains("connection refused"));
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if net.inner.current_index().await.unwrap() == 1 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
     #[tokio::test]
     async fn test_fallback_net_uses_first_healthy_proxy() {
         let dead = delay_net("dead", Duration::from_millis(0));
@@ -178,6 +362,8 @@ mod tests {
             list: vec![dead.clone(), healthy.clone()],
             url: "http://127.0.0.1:18082/".to_string(),
             interval: 60,
+            test_timeout: DEFAULT_TEST_TIMEOUT_MS,
+            max_failed_times: DEFAULT_MAX_FAILED_TIMES,
         })
         .unwrap();
 

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -1,0 +1,186 @@
+use rd_interface::prelude::*;
+use rd_interface::{
+    async_trait, registry::Builder, Address, Context, INet, Net, Registry, Result, TcpBind,
+    TcpConnect, TcpListener, TcpStream, UdpBind, UdpSocket,
+};
+
+use crate::auto_select::{default_test_url, AutoSelectCore, AutoSelectMode};
+
+#[rd_config]
+#[derive(Debug, Clone)]
+pub struct FallbackNetConfig {
+    selected: rd_interface::registry::NetRef,
+    list: Vec<rd_interface::registry::NetRef>,
+    #[serde(default = "default_test_url")]
+    url: String,
+    #[serde(default)]
+    interval: u64,
+}
+
+pub struct FallbackNet {
+    inner: AutoSelectCore,
+}
+
+impl FallbackNet {
+    pub fn new(config: FallbackNetConfig) -> Result<Self> {
+        Ok(Self {
+            inner: AutoSelectCore::new(
+                AutoSelectMode::Fallback,
+                config.selected,
+                config.list,
+                config.url,
+                config.interval,
+                0,
+            )?,
+        })
+    }
+}
+
+#[async_trait]
+impl INet for FallbackNet {
+    fn provide_tcp_connect(&self) -> Option<&dyn rd_interface::TcpConnect> {
+        Some(self)
+    }
+
+    fn provide_tcp_bind(&self) -> Option<&dyn rd_interface::TcpBind> {
+        Some(self)
+    }
+
+    fn provide_udp_bind(&self) -> Option<&dyn rd_interface::UdpBind> {
+        Some(self)
+    }
+
+    fn provide_lookup_host(&self) -> Option<&dyn rd_interface::LookupHost> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl TcpConnect for FallbackNet {
+    async fn tcp_connect(&self, ctx: &mut Context, addr: &Address) -> Result<TcpStream> {
+        self.inner.current_net().await?.tcp_connect(ctx, addr).await
+    }
+}
+
+#[async_trait]
+impl TcpBind for FallbackNet {
+    async fn tcp_bind(&self, ctx: &mut Context, addr: &Address) -> Result<TcpListener> {
+        self.inner.current_net().await?.tcp_bind(ctx, addr).await
+    }
+}
+
+#[async_trait]
+impl UdpBind for FallbackNet {
+    async fn udp_bind(&self, ctx: &mut Context, addr: &Address) -> Result<UdpSocket> {
+        self.inner.current_net().await?.udp_bind(ctx, addr).await
+    }
+}
+
+#[async_trait]
+impl rd_interface::LookupHost for FallbackNet {
+    async fn lookup_host(&self, addr: &Address) -> Result<Vec<std::net::SocketAddr>> {
+        self.inner.current_net().await?.lookup_host(addr).await
+    }
+}
+
+impl Builder<Net> for FallbackNet {
+    const NAME: &'static str = "fallback";
+    type Config = FallbackNetConfig;
+    type Item = Self;
+
+    fn build(config: Self::Config) -> Result<Self> {
+        FallbackNet::new(config)
+    }
+}
+
+pub fn init(registry: &mut Registry) -> Result<()> {
+    registry.add_net::<FallbackNet>();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rd_interface::{registry::NetRef, IntoDyn};
+    use rd_std::tests::{spawn_echo_server, TestNet};
+    use tokio::time::Duration;
+
+    use super::*;
+
+    struct DelayNet {
+        inner: Net,
+        delay: Duration,
+    }
+
+    impl DelayNet {
+        fn new(inner: Net, delay: Duration) -> Self {
+            Self { inner, delay }
+        }
+    }
+
+    #[async_trait]
+    impl rd_interface::TcpConnect for DelayNet {
+        async fn tcp_connect(&self, ctx: &mut Context, addr: &Address) -> Result<TcpStream> {
+            tokio::time::sleep(self.delay).await;
+            self.inner.tcp_connect(ctx, addr).await
+        }
+    }
+
+    #[async_trait]
+    impl rd_interface::TcpBind for DelayNet {
+        async fn tcp_bind(&self, ctx: &mut Context, addr: &Address) -> Result<TcpListener> {
+            self.inner.tcp_bind(ctx, addr).await
+        }
+    }
+
+    #[async_trait]
+    impl rd_interface::UdpBind for DelayNet {
+        async fn udp_bind(&self, ctx: &mut Context, addr: &Address) -> Result<UdpSocket> {
+            self.inner.udp_bind(ctx, addr).await
+        }
+    }
+
+    #[async_trait]
+    impl rd_interface::LookupHost for DelayNet {
+        async fn lookup_host(&self, addr: &Address) -> Result<Vec<std::net::SocketAddr>> {
+            self.inner.lookup_host(addr).await
+        }
+    }
+
+    #[async_trait]
+    impl INet for DelayNet {
+        fn provide_tcp_connect(&self) -> Option<&dyn rd_interface::TcpConnect> {
+            Some(self)
+        }
+        fn provide_tcp_bind(&self) -> Option<&dyn rd_interface::TcpBind> {
+            Some(self)
+        }
+        fn provide_udp_bind(&self) -> Option<&dyn rd_interface::UdpBind> {
+            Some(self)
+        }
+        fn provide_lookup_host(&self) -> Option<&dyn rd_interface::LookupHost> {
+            Some(self)
+        }
+    }
+
+    fn delay_net(name: &str, delay: Duration) -> NetRef {
+        let inner = TestNet::new().into_dyn();
+        NetRef::new_with_value(name.into(), DelayNet::new(inner, delay).into_dyn())
+    }
+
+    #[tokio::test]
+    async fn test_fallback_net_uses_first_healthy_proxy() {
+        let dead = delay_net("dead", Duration::from_millis(0));
+        let healthy = delay_net("healthy", Duration::from_millis(5));
+        spawn_echo_server(&healthy.value_cloned(), "127.0.0.1:18082").await;
+
+        let net = FallbackNet::new(FallbackNetConfig {
+            selected: dead.clone(),
+            list: vec![dead.clone(), healthy.clone()],
+            url: "http://127.0.0.1:18082/".to_string(),
+            interval: 60,
+        })
+        .unwrap();
+
+        assert_eq!(net.inner.current_index().await.unwrap(), 1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,15 @@ use yaml_merge_keys::merge_keys_serde;
 
 #[cfg(feature = "api_server")]
 pub mod api_server;
+mod auto_select;
 pub mod config;
+mod fallback;
 pub mod log;
 pub mod schema;
 mod select;
 pub mod service;
 pub mod storage;
+mod url_test;
 pub mod util;
 
 pub fn get_registry() -> Result<Registry> {
@@ -33,6 +36,8 @@ pub fn get_registry() -> Result<Registry> {
     registry.init_with_registry("vless", vless::init)?;
 
     registry.init_with_registry("rabbit-digger-pro", select::init)?;
+    registry.init_with_registry("rabbit-digger-pro", url_test::init)?;
+    registry.init_with_registry("rabbit-digger-pro", fallback::init)?;
 
     Ok(registry)
 }

--- a/src/select.rs
+++ b/src/select.rs
@@ -26,6 +26,7 @@ impl SelectNet {
             selected: config.selected.value_cloned(),
         })
     }
+
     fn net(&self) -> Option<&Net> {
         Some(&self.selected)
     }

--- a/src/url_test.rs
+++ b/src/url_test.rs
@@ -1,0 +1,267 @@
+use rd_interface::prelude::*;
+use rd_interface::{
+    async_trait, registry::Builder, Address, Context, INet, Net, Registry, Result, TcpBind,
+    TcpConnect, TcpListener, TcpStream, UdpBind, UdpSocket,
+};
+
+use crate::auto_select::{default_test_url, AutoSelectCore, AutoSelectMode};
+
+#[rd_config]
+#[derive(Debug, Clone)]
+pub struct UrlTestNetConfig {
+    selected: rd_interface::registry::NetRef,
+    list: Vec<rd_interface::registry::NetRef>,
+    #[serde(default = "default_test_url")]
+    url: String,
+    #[serde(default)]
+    interval: u64,
+    #[serde(default)]
+    tolerance: u64,
+}
+
+pub struct UrlTestNet {
+    inner: AutoSelectCore,
+}
+
+impl UrlTestNet {
+    pub fn new(config: UrlTestNetConfig) -> Result<Self> {
+        Ok(Self {
+            inner: AutoSelectCore::new(
+                AutoSelectMode::UrlTest,
+                config.selected,
+                config.list,
+                config.url,
+                config.interval,
+                config.tolerance,
+            )?,
+        })
+    }
+}
+
+#[async_trait]
+impl INet for UrlTestNet {
+    fn provide_tcp_connect(&self) -> Option<&dyn rd_interface::TcpConnect> {
+        Some(self)
+    }
+
+    fn provide_tcp_bind(&self) -> Option<&dyn rd_interface::TcpBind> {
+        Some(self)
+    }
+
+    fn provide_udp_bind(&self) -> Option<&dyn rd_interface::UdpBind> {
+        Some(self)
+    }
+
+    fn provide_lookup_host(&self) -> Option<&dyn rd_interface::LookupHost> {
+        Some(self)
+    }
+}
+
+#[async_trait]
+impl TcpConnect for UrlTestNet {
+    async fn tcp_connect(&self, ctx: &mut Context, addr: &Address) -> Result<TcpStream> {
+        self.inner.current_net().await?.tcp_connect(ctx, addr).await
+    }
+}
+
+#[async_trait]
+impl TcpBind for UrlTestNet {
+    async fn tcp_bind(&self, ctx: &mut Context, addr: &Address) -> Result<TcpListener> {
+        self.inner.current_net().await?.tcp_bind(ctx, addr).await
+    }
+}
+
+#[async_trait]
+impl UdpBind for UrlTestNet {
+    async fn udp_bind(&self, ctx: &mut Context, addr: &Address) -> Result<UdpSocket> {
+        self.inner.current_net().await?.udp_bind(ctx, addr).await
+    }
+}
+
+#[async_trait]
+impl rd_interface::LookupHost for UrlTestNet {
+    async fn lookup_host(&self, addr: &Address) -> Result<Vec<std::net::SocketAddr>> {
+        self.inner.current_net().await?.lookup_host(addr).await
+    }
+}
+
+impl Builder<Net> for UrlTestNet {
+    const NAME: &'static str = "url-test";
+    type Config = UrlTestNetConfig;
+    type Item = Self;
+
+    fn build(config: Self::Config) -> Result<Self> {
+        UrlTestNet::new(config)
+    }
+}
+
+pub fn init(registry: &mut Registry) -> Result<()> {
+    registry.add_net::<UrlTestNet>();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rd_interface::{registry::NetRef, IntoAddress, IntoDyn};
+    use rd_std::tests::{assert_net_provider, spawn_echo_server, ProviderCapability, TestNet};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::time::Duration;
+
+    use super::*;
+
+    struct DelayNet {
+        inner: Net,
+        delay: Duration,
+    }
+
+    impl DelayNet {
+        fn new(inner: Net, delay: Duration) -> Self {
+            Self { inner, delay }
+        }
+    }
+
+    #[async_trait]
+    impl rd_interface::TcpConnect for DelayNet {
+        async fn tcp_connect(&self, ctx: &mut Context, addr: &Address) -> Result<TcpStream> {
+            tokio::time::sleep(self.delay).await;
+            self.inner.tcp_connect(ctx, addr).await
+        }
+    }
+
+    #[async_trait]
+    impl rd_interface::TcpBind for DelayNet {
+        async fn tcp_bind(&self, ctx: &mut Context, addr: &Address) -> Result<TcpListener> {
+            self.inner.tcp_bind(ctx, addr).await
+        }
+    }
+
+    #[async_trait]
+    impl rd_interface::UdpBind for DelayNet {
+        async fn udp_bind(&self, ctx: &mut Context, addr: &Address) -> Result<UdpSocket> {
+            self.inner.udp_bind(ctx, addr).await
+        }
+    }
+
+    #[async_trait]
+    impl rd_interface::LookupHost for DelayNet {
+        async fn lookup_host(&self, addr: &Address) -> Result<Vec<std::net::SocketAddr>> {
+            self.inner.lookup_host(addr).await
+        }
+    }
+
+    #[async_trait]
+    impl INet for DelayNet {
+        fn provide_tcp_connect(&self) -> Option<&dyn rd_interface::TcpConnect> {
+            Some(self)
+        }
+        fn provide_tcp_bind(&self) -> Option<&dyn rd_interface::TcpBind> {
+            Some(self)
+        }
+        fn provide_udp_bind(&self) -> Option<&dyn rd_interface::UdpBind> {
+            Some(self)
+        }
+        fn provide_lookup_host(&self) -> Option<&dyn rd_interface::LookupHost> {
+            Some(self)
+        }
+    }
+
+    fn delay_net(name: &str, delay: Duration) -> NetRef {
+        let inner = TestNet::new().into_dyn();
+        NetRef::new_with_value(name.into(), DelayNet::new(inner, delay).into_dyn())
+    }
+
+    async fn assert_stream_echo(stream: &mut TcpStream, payload: &[u8]) {
+        stream.write_all(payload).await.unwrap();
+        stream.flush().await.unwrap();
+        let mut buf = vec![0u8; payload.len()];
+        stream.read_exact(&mut buf).await.unwrap();
+        assert_eq!(buf, payload);
+    }
+
+    #[test]
+    fn test_provider() {
+        let net = NetRef::new_with_value("test".into(), TestNet::new().into_dyn());
+        let url_test = UrlTestNet::new(UrlTestNetConfig {
+            selected: net.clone(),
+            list: vec![net],
+            url: "http://127.0.0.1:80/".to_string(),
+            interval: 0,
+            tolerance: 0,
+        })
+        .unwrap()
+        .into_dyn();
+
+        assert_net_provider(
+            &url_test,
+            ProviderCapability {
+                tcp_connect: true,
+                tcp_bind: true,
+                udp_bind: true,
+                lookup_host: true,
+            },
+        );
+    }
+
+    #[tokio::test]
+    async fn test_url_test_net_prefers_lower_delay() {
+        let fast = delay_net("fast", Duration::from_millis(5));
+        let slow = delay_net("slow", Duration::from_millis(40));
+        spawn_echo_server(&fast.value_cloned(), "127.0.0.1:18080").await;
+        spawn_echo_server(&slow.value_cloned(), "127.0.0.1:18080").await;
+
+        let net = UrlTestNet::new(UrlTestNetConfig {
+            selected: slow.clone(),
+            list: vec![slow.clone(), fast.clone()],
+            url: "http://127.0.0.1:18080/".to_string(),
+            interval: 60,
+            tolerance: 0,
+        })
+        .unwrap();
+
+        assert_eq!(net.inner.current_index().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_url_test_net_respects_tolerance() {
+        let current = delay_net("current", Duration::from_millis(20));
+        let challenger = delay_net("challenger", Duration::from_millis(10));
+        spawn_echo_server(&current.value_cloned(), "127.0.0.1:18081").await;
+        spawn_echo_server(&challenger.value_cloned(), "127.0.0.1:18081").await;
+
+        let net = UrlTestNet::new(UrlTestNetConfig {
+            selected: current.clone(),
+            list: vec![current.clone(), challenger.clone()],
+            url: "http://127.0.0.1:18081/".to_string(),
+            interval: 60,
+            tolerance: 15,
+        })
+        .unwrap();
+
+        assert_eq!(net.inner.current_index().await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_url_test_net_routes_through_selected_proxy() {
+        let fast = delay_net("fast", Duration::from_millis(5));
+        let slow = delay_net("slow", Duration::from_millis(40));
+        spawn_echo_server(&fast.value_cloned(), "127.0.0.1:18083").await;
+        spawn_echo_server(&slow.value_cloned(), "127.0.0.1:18083").await;
+
+        let net = UrlTestNet::new(UrlTestNetConfig {
+            selected: slow.clone(),
+            list: vec![slow.clone(), fast.clone()],
+            url: "http://127.0.0.1:18083/".to_string(),
+            interval: 60,
+            tolerance: 0,
+        })
+        .unwrap()
+        .into_dyn();
+
+        let mut ctx = Context::new();
+        let mut stream = net
+            .tcp_connect(&mut ctx, &("127.0.0.1", 18083).into_address().unwrap())
+            .await
+            .unwrap();
+        assert_stream_echo(&mut stream, b"hello").await;
+    }
+}

--- a/src/url_test.rs
+++ b/src/url_test.rs
@@ -4,7 +4,18 @@ use rd_interface::{
     TcpConnect, TcpListener, TcpStream, UdpBind, UdpSocket,
 };
 
-use crate::auto_select::{default_test_url, AutoSelectCore, AutoSelectMode};
+use crate::auto_select::{
+    default_test_url, AutoSelectCore, AutoSelectMode, DEFAULT_MAX_FAILED_TIMES,
+    DEFAULT_TEST_TIMEOUT_MS,
+};
+
+fn default_test_timeout() -> u64 {
+    DEFAULT_TEST_TIMEOUT_MS
+}
+
+fn default_max_failed_times() -> u32 {
+    DEFAULT_MAX_FAILED_TIMES
+}
 
 #[rd_config]
 #[derive(Debug, Clone)]
@@ -17,6 +28,10 @@ pub struct UrlTestNetConfig {
     interval: u64,
     #[serde(default)]
     tolerance: u64,
+    #[serde(default = "default_test_timeout")]
+    test_timeout: u64,
+    #[serde(default = "default_max_failed_times")]
+    max_failed_times: u32,
 }
 
 pub struct UrlTestNet {
@@ -33,6 +48,8 @@ impl UrlTestNet {
                 config.url,
                 config.interval,
                 config.tolerance,
+                config.test_timeout,
+                config.max_failed_times,
             )?,
         })
     }
@@ -60,28 +77,68 @@ impl INet for UrlTestNet {
 #[async_trait]
 impl TcpConnect for UrlTestNet {
     async fn tcp_connect(&self, ctx: &mut Context, addr: &Address) -> Result<TcpStream> {
-        self.inner.current_net().await?.tcp_connect(ctx, addr).await
+        let net = self.inner.current_net().await?;
+        match net.tcp_connect(ctx, addr).await {
+            Ok(stream) => {
+                self.inner.on_operation_success().await;
+                Ok(stream)
+            }
+            Err(err) => {
+                self.inner.on_operation_failure(&err).await;
+                Err(err)
+            }
+        }
     }
 }
 
 #[async_trait]
 impl TcpBind for UrlTestNet {
     async fn tcp_bind(&self, ctx: &mut Context, addr: &Address) -> Result<TcpListener> {
-        self.inner.current_net().await?.tcp_bind(ctx, addr).await
+        let net = self.inner.current_net().await?;
+        match net.tcp_bind(ctx, addr).await {
+            Ok(listener) => {
+                self.inner.on_operation_success().await;
+                Ok(listener)
+            }
+            Err(err) => {
+                self.inner.on_operation_failure(&err).await;
+                Err(err)
+            }
+        }
     }
 }
 
 #[async_trait]
 impl UdpBind for UrlTestNet {
     async fn udp_bind(&self, ctx: &mut Context, addr: &Address) -> Result<UdpSocket> {
-        self.inner.current_net().await?.udp_bind(ctx, addr).await
+        let net = self.inner.current_net().await?;
+        match net.udp_bind(ctx, addr).await {
+            Ok(socket) => {
+                self.inner.on_operation_success().await;
+                Ok(socket)
+            }
+            Err(err) => {
+                self.inner.on_operation_failure(&err).await;
+                Err(err)
+            }
+        }
     }
 }
 
 #[async_trait]
 impl rd_interface::LookupHost for UrlTestNet {
     async fn lookup_host(&self, addr: &Address) -> Result<Vec<std::net::SocketAddr>> {
-        self.inner.current_net().await?.lookup_host(addr).await
+        let net = self.inner.current_net().await?;
+        match net.lookup_host(addr).await {
+            Ok(addrs) => {
+                self.inner.on_operation_success().await;
+                Ok(addrs)
+            }
+            Err(err) => {
+                self.inner.on_operation_failure(&err).await;
+                Err(err)
+            }
+        }
     }
 }
 
@@ -102,8 +159,12 @@ pub fn init(registry: &mut Registry) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use rd_interface::{registry::NetRef, IntoAddress, IntoDyn};
+    use rd_interface::{registry::NetRef, Error, IntoAddress, IntoDyn};
     use rd_std::tests::{assert_net_provider, spawn_echo_server, ProviderCapability, TestNet};
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::time::Duration;
 
@@ -170,6 +231,87 @@ mod tests {
         NetRef::new_with_value(name.into(), DelayNet::new(inner, delay).into_dyn())
     }
 
+    struct ToggleNet {
+        inner: Net,
+        alive: Arc<AtomicBool>,
+        delay: Duration,
+    }
+
+    impl ToggleNet {
+        fn new(inner: Net, alive: Arc<AtomicBool>, delay: Duration) -> Self {
+            Self {
+                inner,
+                alive,
+                delay,
+            }
+        }
+
+        fn ensure_alive(&self) -> Result<()> {
+            if self.alive.load(Ordering::SeqCst) {
+                Ok(())
+            } else {
+                Err(Error::from(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionRefused,
+                    "connection refused",
+                )))
+            }
+        }
+    }
+
+    #[async_trait]
+    impl rd_interface::TcpConnect for ToggleNet {
+        async fn tcp_connect(&self, ctx: &mut Context, addr: &Address) -> Result<TcpStream> {
+            self.ensure_alive()?;
+            tokio::time::sleep(self.delay).await;
+            self.inner.tcp_connect(ctx, addr).await
+        }
+    }
+
+    #[async_trait]
+    impl rd_interface::TcpBind for ToggleNet {
+        async fn tcp_bind(&self, ctx: &mut Context, addr: &Address) -> Result<TcpListener> {
+            self.ensure_alive()?;
+            self.inner.tcp_bind(ctx, addr).await
+        }
+    }
+
+    #[async_trait]
+    impl rd_interface::UdpBind for ToggleNet {
+        async fn udp_bind(&self, ctx: &mut Context, addr: &Address) -> Result<UdpSocket> {
+            self.ensure_alive()?;
+            self.inner.udp_bind(ctx, addr).await
+        }
+    }
+
+    #[async_trait]
+    impl rd_interface::LookupHost for ToggleNet {
+        async fn lookup_host(&self, addr: &Address) -> Result<Vec<std::net::SocketAddr>> {
+            self.ensure_alive()?;
+            self.inner.lookup_host(addr).await
+        }
+    }
+
+    #[async_trait]
+    impl INet for ToggleNet {
+        fn provide_tcp_connect(&self) -> Option<&dyn rd_interface::TcpConnect> {
+            Some(self)
+        }
+        fn provide_tcp_bind(&self) -> Option<&dyn rd_interface::TcpBind> {
+            Some(self)
+        }
+        fn provide_udp_bind(&self) -> Option<&dyn rd_interface::UdpBind> {
+            Some(self)
+        }
+        fn provide_lookup_host(&self) -> Option<&dyn rd_interface::LookupHost> {
+            Some(self)
+        }
+    }
+
+    fn toggle_net(name: &str, alive: Arc<AtomicBool>, delay: Duration) -> NetRef {
+        let inner = TestNet::new().into_dyn();
+        NetRef::new_with_value(name.into(), ToggleNet::new(inner, alive, delay).into_dyn())
+    }
+
     async fn assert_stream_echo(stream: &mut TcpStream, payload: &[u8]) {
         stream.write_all(payload).await.unwrap();
         stream.flush().await.unwrap();
@@ -187,6 +329,8 @@ mod tests {
             url: "http://127.0.0.1:80/".to_string(),
             interval: 0,
             tolerance: 0,
+            test_timeout: DEFAULT_TEST_TIMEOUT_MS,
+            max_failed_times: DEFAULT_MAX_FAILED_TIMES,
         })
         .unwrap()
         .into_dyn();
@@ -215,6 +359,8 @@ mod tests {
             url: "http://127.0.0.1:18080/".to_string(),
             interval: 60,
             tolerance: 0,
+            test_timeout: DEFAULT_TEST_TIMEOUT_MS,
+            max_failed_times: DEFAULT_MAX_FAILED_TIMES,
         })
         .unwrap();
 
@@ -234,10 +380,55 @@ mod tests {
             url: "http://127.0.0.1:18081/".to_string(),
             interval: 60,
             tolerance: 15,
+            test_timeout: DEFAULT_TEST_TIMEOUT_MS,
+            max_failed_times: DEFAULT_MAX_FAILED_TIMES,
         })
         .unwrap();
 
         assert_eq!(net.inner.current_index().await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_url_test_net_failed_request_does_not_retry_but_refreshes_health() {
+        let current_alive = Arc::new(AtomicBool::new(true));
+        let backup_alive = Arc::new(AtomicBool::new(true));
+        let current = toggle_net("current", current_alive.clone(), Duration::from_millis(5));
+        let backup = toggle_net("backup", backup_alive, Duration::from_millis(20));
+        spawn_echo_server(&current.value_cloned(), "127.0.0.1:18084").await;
+        spawn_echo_server(&backup.value_cloned(), "127.0.0.1:18084").await;
+
+        let net = UrlTestNet::new(UrlTestNetConfig {
+            selected: current.clone(),
+            list: vec![current.clone(), backup.clone()],
+            url: "http://127.0.0.1:18084/".to_string(),
+            interval: 60,
+            tolerance: 0,
+            test_timeout: DEFAULT_TEST_TIMEOUT_MS,
+            max_failed_times: DEFAULT_MAX_FAILED_TIMES,
+        })
+        .unwrap();
+
+        assert_eq!(net.inner.current_index().await.unwrap(), 0);
+        current_alive.store(false, Ordering::SeqCst);
+
+        let mut ctx = Context::new();
+        let err = net
+            .tcp_connect(&mut ctx, &("127.0.0.1", 18084).into_address().unwrap())
+            .await
+            .err()
+            .unwrap();
+        assert!(err.to_string().contains("connection refused"));
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if net.inner.current_index().await.unwrap() == 1 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
     }
 
     #[tokio::test]
@@ -253,6 +444,8 @@ mod tests {
             url: "http://127.0.0.1:18083/".to_string(),
             interval: 60,
             tolerance: 0,
+            test_timeout: DEFAULT_TEST_TIMEOUT_MS,
+            max_failed_times: DEFAULT_MAX_FAILED_TIMES,
         })
         .unwrap()
         .into_dyn();

--- a/webui/src/pages/select-nets-page.tsx
+++ b/webui/src/pages/select-nets-page.tsx
@@ -1,7 +1,7 @@
 import { useDeferredValue, useMemo, useState } from 'react'
 
 import { rdpApi } from '../api'
-import type { RdpConfig } from '../types'
+import type { NetConfig, RdpConfig } from '../types'
 import { classNames, getSelectGroups } from '../utils'
 
 const DELAY_TEST_URL = 'http://www.gstatic.com/generate_204'
@@ -46,6 +46,27 @@ function getDelayColor(state?: DelayState): string {
     case 'error':
       return 'text-rose-500'
   }
+}
+
+function getGroupBadge(net: NetConfig): { label: string; className: string } {
+  switch (net.type) {
+    case 'url-test':
+      return { label: 'URL Test', className: 'bg-emerald-50 text-emerald-700' }
+    case 'fallback':
+      return { label: 'Fallback', className: 'bg-amber-50 text-amber-700' }
+    default:
+      return { label: 'Selector', className: 'bg-sky-50 text-sky-600' }
+  }
+}
+
+function getGroupMeta(net: NetConfig): string | null {
+  const facts: string[] = []
+  if (typeof net.url === 'string' && net.url) facts.push(net.url)
+  if (typeof net.interval === 'number') facts.push(`每 ${net.interval}s 检查`)
+  if (typeof net.tolerance === 'number' && net.type === 'url-test') {
+    facts.push(`容差 ${net.tolerance}ms`)
+  }
+  return facts.length > 0 ? facts.join(' · ') : null
 }
 
 export function SelectNetsPage({
@@ -148,6 +169,9 @@ export function SelectNetsPage({
         const selected = net.selected
         const options = net.list ?? []
         const isExpanded = deferredQuery ? true : expandedGroups[groupName] ?? index === 0
+        const badge = getGroupBadge(net)
+        const groupMeta = getGroupMeta(net)
+        const isManualGroup = net.type === 'select'
 
         return (
           <section key={groupName} className="surface overflow-hidden">
@@ -162,10 +186,11 @@ export function SelectNetsPage({
               <h2 className="font-display text-sm font-semibold text-slate-900 truncate">
                 {groupName}
               </h2>
-              <span className="tag bg-sky-50 text-sky-600">Selector</span>
+              <span className={classNames('tag', badge.className)}>{badge.label}</span>
               <span className="text-xs text-slate-500 truncate">
                 {selected ?? '未选择'}
               </span>
+              {groupMeta && <span className="hidden text-xs text-slate-400 xl:block truncate">{groupMeta}</span>}
               <span className="ml-auto text-xs font-medium text-slate-400">{options.length}</span>
               <svg
                 className={classNames(
@@ -194,6 +219,11 @@ export function SelectNetsPage({
                   >
                     {activeDelayScope === groupName ? '测试中...' : '测速本组'}
                   </button>
+                  {!isManualGroup && (
+                    <span className="text-xs text-slate-500">
+                      自动组，当前展示的是运行时选中结果
+                    </span>
+                  )}
                 </div>
 
                 <div className="grid gap-2 grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
@@ -202,6 +232,7 @@ export function SelectNetsPage({
                     const isBusy = busyNet === groupName
                     const delayState = delayResults[optionName]
                     const delayLabel = getDelayLabel(delayState)
+                    const canSelect = isManualGroup
 
                     return (
                       <button
@@ -212,10 +243,14 @@ export function SelectNetsPage({
                           isSelected
                             ? 'border-sky-400 bg-sky-600 text-white shadow-sm'
                             : 'border-slate-200 bg-white/60 hover:bg-white hover:border-slate-300',
-                          isBusy && 'cursor-wait opacity-60',
+                          (isBusy || !canSelect) && 'cursor-not-allowed',
+                          isBusy && 'opacity-60',
+                          !canSelect && 'opacity-80',
                         )}
-                        onClick={() => void onSelect(groupName, optionName)}
-                        disabled={isBusy}
+                        onClick={() => {
+                          if (canSelect) void onSelect(groupName, optionName)
+                        }}
+                        disabled={isBusy || !canSelect}
                       >
                         <p className="truncate text-sm font-medium">{optionName}</p>
                         <div className="mt-1 flex items-center justify-between">

--- a/webui/src/types.ts
+++ b/webui/src/types.ts
@@ -5,6 +5,9 @@ export interface NetConfig {
   server?: string
   net?: unknown
   sni?: string
+  url?: string
+  interval?: number
+  tolerance?: number
   [key: string]: unknown
 }
 

--- a/webui/src/utils.ts
+++ b/webui/src/utils.ts
@@ -214,7 +214,7 @@ export function getSelectGroups(config: RdpConfig | null): Array<[string, NetCon
   }
 
   return Object.entries(config.net)
-    .filter(([, net]) => net.type === 'select')
+    .filter(([, net]) => ['select', 'url-test', 'fallback'].includes(net.type))
     .sort(([leftName], [rightName]) => {
       if (leftName === 'select-net') {
         return 1


### PR DESCRIPTION
## Summary
- add support for `behavior: classical` in Clash/Mihomo `rule-providers`
- expand `RULE-SET` payloads into multiple rule items when needed
- ensure classical payload rules inherit the outer `RULE-SET` target
- add regression tests for classical ruleset expansion and process-time flattening

## Validation
- `cargo test config::importer::clash::tests:: -- --nocapture`
- `cargo test --all`

## Notes
- I initially handled a missing blob file the wrong way; corrected by initializing the repo submodule and re-running verification from the proper repo state.