### PR TITLE
feat: add AnyTLS protocol support

### DIFF
--- a/.github/workflows/protocol-interop.yml
+++ b/.github/workflows/protocol-interop.yml
@@ -1,0 +1,64 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Protocol Interop
+
+on:
+  push:
+    branches: [main, feat/anytls-protocol]
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      protocol:
+        description: Protocol to test
+        required: false
+        default: all
+        type: choice
+        options:
+          - all
+          - shadowsocks
+          - trojan
+          - vless
+          - hysteria
+          - anytls
+
+jobs:
+  interop:
+    name: ${{ matrix.protocol }} official binary interop
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        protocol: [shadowsocks, trojan, vless, hysteria, anytls]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build interop image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: scripts/interop.Dockerfile
+          load: true
+          tags: rdp-protocol-interop:ci
+          cache-from: type=gha,scope=protocol-interop-${{ runner.os }}
+          cache-to: type=gha,mode=max,scope=protocol-interop-${{ runner.os }}
+
+      - name: Run protocol interop
+        run: |
+          protocol="${{ github.event.inputs.protocol || matrix.protocol }}"
+          if [ "${protocol}" != "all" ] && [ "${protocol}" != "${{ matrix.protocol }}" ]; then
+            echo "Skipping ${{ matrix.protocol }} because workflow_dispatch requested ${protocol}"
+            exit 0
+          fi
+          docker run --rm \
+            --network host \
+            -e CARGO_HOME=/usr/local/cargo \
+            -e KEEP_TMP=${KEEP_TMP:-0} \
+            -v "$PWD:/workspace" \
+            -w /workspace \
+            rdp-protocol-interop:ci \
+            bash scripts/protocol_interop_e2e.sh "${{ matrix.protocol }}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
 
 [[package]]
+name = "anytls"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "futures",
+ "md5",
+ "rand 0.9.2",
+ "rd-interface",
+ "rd-std",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "tokio-rustls",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,6 +2393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3168,6 +3192,7 @@ name = "rabbit-digger-pro"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "anytls",
  "async-stream",
  "axum",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ raw = { path = "./protocol/raw", optional = true }
 obfs = { path = "./protocol/obfs", optional = true }
 hysteria = { path = "./protocol/hysteria", optional = true }
 vless = { path = "./protocol/vless", optional = true }
+anytls = { path = "./protocol/anytls", optional = true }
 
 console-subscriber = { version = "0.5.0", optional = true }
 
@@ -105,6 +106,7 @@ default = [
     "obfs",
     "hysteria",
     "vless",
+    "anytls",
     "api_server",
     "rhai",
     "raw",
@@ -145,6 +147,7 @@ members = [
     "protocol/obfs",
     "protocol/hysteria",
     "protocol/vless",
+    "protocol/anytls",
     "ffi",
 ]
 

--- a/protocol/anytls/Cargo.toml
+++ b/protocol/anytls/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "anytls"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rd-interface = { path = "../../rd-interface", version = "0.4" }
+rd-std = { path = "../../rd-std", version = "0.1" }
+serde = "1.0"
+tokio = { version = "1.50.0", features = ["full"] }
+bytes = "1.11.0"
+futures = "0.3"
+tokio-rustls = "0.26.4"
+webpki-roots = "0.26.11"
+sha2 = "0.10.9"
+md5 = "0.8.0"
+rand = "0.9.2"
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/protocol/anytls/src/client.rs
+++ b/protocol/anytls/src/client.rs
@@ -1,0 +1,341 @@
+use std::{
+    io,
+    net::SocketAddr,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use crate::proto::*;
+use bytes::BytesMut;
+use futures::ready;
+use rd_interface::{
+    async_trait, config::NetRef, prelude::*, Address, INet, IntoDyn, Result, TcpStream,
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    sync::{mpsc, Mutex},
+};
+use tokio_rustls::{
+    rustls::{
+        client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+        crypto::ring,
+        pki_types::{CertificateDer, ServerName, UnixTime},
+        ClientConfig, DigitallySignedStruct, RootCertStore,
+    },
+    TlsConnector,
+};
+
+#[rd_config]
+#[derive(Debug, Clone)]
+pub struct AnyTlsNetConfig {
+    #[serde(default)]
+    pub(crate) net: NetRef,
+    pub(crate) server: Address,
+    pub(crate) password: String,
+    #[serde(default)]
+    pub(crate) sni: Option<String>,
+    #[serde(default)]
+    pub(crate) skip_cert_verify: bool,
+}
+
+pub struct AnyTlsNet {
+    net: rd_interface::Net,
+    server: Address,
+    password: String,
+    server_name: String,
+    connector: TlsConnector,
+    padding: Arc<Mutex<PaddingScheme>>,
+}
+
+#[derive(Debug)]
+struct AllowAnyCert(Arc<dyn ServerCertVerifier>);
+
+impl ServerCertVerifier for AllowAnyCert {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> std::result::Result<ServerCertVerified, tokio_rustls::rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, tokio_rustls::rustls::Error> {
+        self.0.verify_tls12_signature(message, cert, dss)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, tokio_rustls::rustls::Error> {
+        self.0.verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<tokio_rustls::rustls::SignatureScheme> {
+        self.0.supported_verify_schemes()
+    }
+}
+
+impl AnyTlsNet {
+    pub fn new(config: AnyTlsNetConfig) -> Result<Self> {
+        let _ = ring::default_provider().install_default();
+        let AnyTlsNetConfig {
+            net,
+            server,
+            password,
+            sni,
+            skip_cert_verify,
+        } = config;
+        let server_name = sni.unwrap_or_else(|| server.host());
+        let mut roots = RootCertStore::empty();
+        roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+        let roots = Arc::new(roots);
+        let builder = ClientConfig::builder();
+        let client_config = if skip_cert_verify {
+            let verifier = tokio_rustls::rustls::client::WebPkiServerVerifier::builder(roots)
+                .build()
+                .map_err(rd_interface::error::map_other)?;
+            builder
+                .dangerous()
+                .with_custom_certificate_verifier(Arc::new(AllowAnyCert(verifier)))
+                .with_no_client_auth()
+        } else {
+            builder.with_root_certificates(roots).with_no_client_auth()
+        };
+
+        Ok(Self {
+            net: net.value_cloned(),
+            server,
+            password,
+            server_name,
+            connector: TlsConnector::from(Arc::new(client_config)),
+            padding: Arc::new(Mutex::new(PaddingScheme::default())),
+        })
+    }
+}
+
+#[async_trait]
+impl rd_interface::TcpConnect for AnyTlsNet {
+    async fn tcp_connect(
+        &self,
+        ctx: &mut rd_interface::Context,
+        addr: &Address,
+    ) -> Result<TcpStream> {
+        let stream = self.net.tcp_connect(ctx, &self.server).await?;
+        let server_name = ServerName::try_from(self.server_name.clone())
+            .map_err(rd_interface::error::map_other)?;
+        let mut tls = self
+            .connector
+            .connect(server_name, stream)
+            .await
+            .map_err(rd_interface::error::map_other)?;
+        let padding = self.padding.lock().await.clone();
+        tls.write_all(&auth_prefix(&self.password, &padding))
+            .await?;
+
+        let (mut reader, mut writer) = tokio::io::split(tls);
+        let (write_tx, mut write_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+        let (read_tx, read_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+        let sid = 1;
+        let writer_padding = self.padding.clone();
+
+        tokio::spawn(async move {
+            let mut pkt = 1u32;
+            while let Some(payload) = write_rx.recv().await {
+                let padding = writer_padding.lock().await.clone();
+                let chunks = apply_padding(pkt, &padding, payload);
+                pkt = pkt.saturating_add(1);
+                for chunk in chunks {
+                    if !chunk.is_empty() && writer.write_all(&chunk).await.is_err() {
+                        let _ = writer.shutdown().await;
+                        return;
+                    }
+                }
+            }
+            let _ = writer.shutdown().await;
+        });
+
+        let recv_write_tx = write_tx.clone();
+        let reader_padding = self.padding.clone();
+        tokio::spawn(async move {
+            let mut header = [0u8; HEADER_LEN];
+            loop {
+                if reader.read_exact(&mut header).await.is_err() {
+                    break;
+                }
+                let (cmd, got_sid, len) = decode_header(header);
+                let mut data = vec![0u8; len as usize];
+                if len > 0 && reader.read_exact(&mut data).await.is_err() {
+                    break;
+                }
+                match cmd {
+                    CMD_PSH if got_sid == sid => {
+                        if read_tx.send(data).is_err() {
+                            break;
+                        }
+                    }
+                    CMD_FIN if got_sid == sid => break,
+                    CMD_ALERT => break,
+                    CMD_UPDATE_PADDING_SCHEME => {
+                        if let Some(padding) = PaddingScheme::parse(&data) {
+                            *reader_padding.lock().await = padding;
+                        }
+                    }
+                    CMD_HEART_REQUEST => {
+                        let _ = recv_write_tx.send(encode_frame(&Frame {
+                            cmd: CMD_HEART_RESPONSE,
+                            sid: got_sid,
+                            data: Vec::new(),
+                        }));
+                    }
+                    CMD_WASTE | CMD_SETTINGS | CMD_SYNACK | CMD_SERVER_SETTINGS
+                    | CMD_HEART_RESPONSE => {}
+                    _ => {}
+                }
+            }
+        });
+
+        let padding = self.padding.lock().await.clone();
+        let mut initial_payload = encode_frame(&Frame {
+            cmd: CMD_SETTINGS,
+            sid: 0,
+            data: encode_settings(&padding),
+        });
+        initial_payload.extend_from_slice(&encode_frame(&Frame {
+            cmd: CMD_SYN,
+            sid,
+            data: Vec::new(),
+        }));
+        initial_payload.extend_from_slice(&encode_frame(&Frame {
+            cmd: CMD_PSH,
+            sid,
+            data: encode_socks_addr(addr)?,
+        }));
+        write_tx
+            .send(initial_payload)
+            .map_err(|_| rd_interface::Error::other("anytls writer closed"))?;
+
+        Ok(AnyTlsStream {
+            sid,
+            write_tx,
+            read_rx,
+            read_buf: BytesMut::new(),
+            closed: false,
+        }
+        .into_dyn())
+    }
+}
+
+impl INet for AnyTlsNet {
+    fn provide_tcp_connect(&self) -> Option<&dyn rd_interface::TcpConnect> {
+        Some(self)
+    }
+}
+
+struct AnyTlsStream {
+    sid: u32,
+    write_tx: mpsc::UnboundedSender<Vec<u8>>,
+    read_rx: mpsc::UnboundedReceiver<Vec<u8>>,
+    read_buf: BytesMut,
+    closed: bool,
+}
+
+#[async_trait]
+impl rd_interface::ITcpStream for AnyTlsStream {
+    async fn peer_addr(&self) -> Result<SocketAddr> {
+        Err(rd_interface::NOT_IMPLEMENTED)
+    }
+
+    async fn local_addr(&self) -> Result<SocketAddr> {
+        Err(rd_interface::NOT_IMPLEMENTED)
+    }
+
+    fn poll_read(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut rd_interface::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if self.read_buf.is_empty() {
+            match ready!(Pin::new(&mut self.read_rx).poll_recv(cx)) {
+                Some(data) => self.read_buf.extend_from_slice(&data),
+                None => return Poll::Ready(Ok(())),
+            }
+        }
+        let n = self.read_buf.len().min(buf.remaining());
+        buf.put_slice(&self.read_buf.split_to(n));
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_write(&mut self, _cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
+        if self.closed {
+            return Poll::Ready(Err(io::ErrorKind::BrokenPipe.into()));
+        }
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+        let n = buf.len().min(u16::MAX as usize);
+        self.write_tx
+            .send(encode_frame(&Frame {
+                cmd: CMD_PSH,
+                sid: self.sid,
+                data: buf[..n].to_vec(),
+            }))
+            .map_err(|_| io::Error::from(io::ErrorKind::BrokenPipe))?;
+        Poll::Ready(Ok(n))
+    }
+
+    fn poll_flush(&mut self, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(&mut self, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        if !self.closed {
+            self.closed = true;
+            let _ = self.write_tx.send(encode_frame(&Frame {
+                cmd: CMD_FIN,
+                sid: self.sid,
+                data: Vec::new(),
+            }));
+        }
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rd_interface::{IntoAddress, IntoDyn};
+    use rd_std::tests::{assert_net_provider, ProviderCapability, TestNet};
+
+    #[test]
+    fn anytls_net_provides_tcp_connect_only() {
+        let net = TestNet::new().into_dyn();
+        let anytls = AnyTlsNet::new(AnyTlsNetConfig {
+            net: NetRef::new_with_value("test".into(), net),
+            server: "127.0.0.1:443".into_address().unwrap(),
+            password: "pw".to_string(),
+            sni: Some("localhost".to_string()),
+            skip_cert_verify: true,
+        })
+        .unwrap()
+        .into_dyn();
+
+        assert_net_provider(
+            &anytls,
+            ProviderCapability {
+                tcp_connect: true,
+                ..Default::default()
+            },
+        );
+    }
+}

--- a/protocol/anytls/src/lib.rs
+++ b/protocol/anytls/src/lib.rs
@@ -1,0 +1,21 @@
+use rd_interface::{registry::Builder, Net, Registry, Result};
+
+mod client;
+mod proto;
+
+pub use client::{AnyTlsNet, AnyTlsNetConfig};
+
+impl Builder<Net> for AnyTlsNet {
+    const NAME: &'static str = "anytls";
+    type Config = AnyTlsNetConfig;
+    type Item = Self;
+
+    fn build(config: Self::Config) -> Result<Self> {
+        AnyTlsNet::new(config)
+    }
+}
+
+pub fn init(registry: &mut Registry) -> Result<()> {
+    registry.add_net::<AnyTlsNet>();
+    Ok(())
+}

--- a/protocol/anytls/src/proto.rs
+++ b/protocol/anytls/src/proto.rs
@@ -1,0 +1,301 @@
+use rd_interface::Address;
+use std::{collections::HashMap, net::IpAddr};
+
+pub(crate) const CMD_WASTE: u8 = 0;
+pub(crate) const CMD_SYN: u8 = 1;
+pub(crate) const CMD_PSH: u8 = 2;
+pub(crate) const CMD_FIN: u8 = 3;
+pub(crate) const CMD_SETTINGS: u8 = 4;
+pub(crate) const CMD_ALERT: u8 = 5;
+pub(crate) const CMD_UPDATE_PADDING_SCHEME: u8 = 6;
+pub(crate) const CMD_SYNACK: u8 = 7;
+pub(crate) const CMD_HEART_REQUEST: u8 = 8;
+pub(crate) const CMD_HEART_RESPONSE: u8 = 9;
+pub(crate) const CMD_SERVER_SETTINGS: u8 = 10;
+
+pub(crate) const HEADER_LEN: usize = 7;
+const CHECK_MARK: i32 = -1;
+const DEFAULT_PADDING_SCHEME: &[u8] = b"stop=8\n0=30-30\n1=100-400\n2=400-500,c,500-1000,c,500-1000,c,500-1000,c,500-1000\n3=9-9,500-1000\n4=500-1000\n5=500-1000\n6=500-1000\n7=500-1000";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Frame {
+    pub(crate) cmd: u8,
+    pub(crate) sid: u32,
+    pub(crate) data: Vec<u8>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PaddingScheme {
+    raw: Vec<u8>,
+    stop: u32,
+    scheme: HashMap<u32, Vec<PaddingPart>>,
+}
+
+#[derive(Debug, Clone)]
+enum PaddingPart {
+    Check,
+    Range { min: usize, max: usize },
+}
+
+impl PaddingScheme {
+    pub(crate) fn default() -> Self {
+        Self::parse(DEFAULT_PADDING_SCHEME).expect("default AnyTLS padding scheme is valid")
+    }
+
+    pub(crate) fn parse(raw: &[u8]) -> Option<Self> {
+        let text = std::str::from_utf8(raw).ok()?;
+        let mut stop = None;
+        let mut scheme = HashMap::new();
+
+        for line in text.lines() {
+            let Some((key, value)) = line.split_once('=') else {
+                continue;
+            };
+            if key == "stop" {
+                stop = value.parse::<u32>().ok();
+                continue;
+            }
+            let Ok(pkt) = key.parse::<u32>() else {
+                continue;
+            };
+            let mut parts = Vec::new();
+            for raw_part in value.split(',') {
+                if raw_part == "c" {
+                    parts.push(PaddingPart::Check);
+                    continue;
+                }
+                let Some((min, max)) = raw_part.split_once('-') else {
+                    continue;
+                };
+                let (Ok(mut min), Ok(mut max)) = (min.parse::<usize>(), max.parse::<usize>())
+                else {
+                    continue;
+                };
+                if min == 0 || max == 0 {
+                    continue;
+                }
+                if min > max {
+                    std::mem::swap(&mut min, &mut max);
+                }
+                parts.push(PaddingPart::Range { min, max });
+            }
+            scheme.insert(pkt, parts);
+        }
+
+        Some(Self {
+            raw: raw.to_vec(),
+            stop: stop?,
+            scheme,
+        })
+    }
+
+    pub(crate) fn md5_hex(&self) -> String {
+        format!("{:x}", md5::compute(&self.raw))
+    }
+
+    pub(crate) fn generate_record_payload_sizes(&self, pkt: u32) -> Vec<i32> {
+        if pkt >= self.stop {
+            return Vec::new();
+        }
+        self.scheme
+            .get(&pkt)
+            .map(|parts| {
+                parts
+                    .iter()
+                    .map(|part| match part {
+                        PaddingPart::Check => CHECK_MARK,
+                        PaddingPart::Range { min, max } => {
+                            if min == max {
+                                *min as i32
+                            } else {
+                                rand::random_range(*min..*max) as i32
+                            }
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+pub(crate) fn encode_frame(frame: &Frame) -> Vec<u8> {
+    assert!(frame.data.len() <= u16::MAX as usize);
+    let mut out = Vec::with_capacity(HEADER_LEN + frame.data.len());
+    out.push(frame.cmd);
+    out.extend_from_slice(&frame.sid.to_be_bytes());
+    out.extend_from_slice(&(frame.data.len() as u16).to_be_bytes());
+    out.extend_from_slice(&frame.data);
+    out
+}
+
+pub(crate) fn decode_header(header: [u8; HEADER_LEN]) -> (u8, u32, u16) {
+    (
+        header[0],
+        u32::from_be_bytes([header[1], header[2], header[3], header[4]]),
+        u16::from_be_bytes([header[5], header[6]]),
+    )
+}
+
+pub(crate) fn encode_socks_addr(addr: &Address) -> rd_interface::Result<Vec<u8>> {
+    let mut out = Vec::new();
+    match addr {
+        Address::SocketAddr(socket) => {
+            match socket.ip() {
+                IpAddr::V4(ip) => {
+                    out.push(1);
+                    out.extend_from_slice(&ip.octets());
+                }
+                IpAddr::V6(ip) => {
+                    out.push(4);
+                    out.extend_from_slice(&ip.octets());
+                }
+            }
+            out.extend_from_slice(&socket.port().to_be_bytes());
+        }
+        Address::Domain(domain, port) => {
+            if domain.len() > u8::MAX as usize {
+                return Err(rd_interface::Error::other("domain name too long"));
+            }
+            out.push(3);
+            out.push(domain.len() as u8);
+            out.extend_from_slice(domain.as_bytes());
+            out.extend_from_slice(&port.to_be_bytes());
+        }
+    }
+    Ok(out)
+}
+
+pub(crate) fn encode_settings(padding: &PaddingScheme) -> Vec<u8> {
+    format!("v=2\nclient=rdp/anytls\npadding-md5={}", padding.md5_hex()).into_bytes()
+}
+
+pub(crate) fn auth_prefix(password: &str, padding: &PaddingScheme) -> Vec<u8> {
+    use sha2::{Digest, Sha256};
+    let mut out = Sha256::digest(password.as_bytes()).to_vec();
+    let padding_len = padding
+        .generate_record_payload_sizes(0)
+        .first()
+        .copied()
+        .filter(|len| *len > 0)
+        .unwrap_or_default() as usize;
+    assert!(padding_len <= u16::MAX as usize);
+    out.extend_from_slice(&(padding_len as u16).to_be_bytes());
+    out.resize(out.len() + padding_len, 0);
+    out
+}
+
+pub(crate) fn encode_waste_frame(padding_len: usize) -> Vec<u8> {
+    encode_frame(&Frame {
+        cmd: CMD_WASTE,
+        sid: 0,
+        data: vec![0; padding_len],
+    })
+}
+
+pub(crate) fn apply_padding(
+    pkt: u32,
+    padding: &PaddingScheme,
+    mut payload: Vec<u8>,
+) -> Vec<Vec<u8>> {
+    let mut out = Vec::new();
+    let sizes = padding.generate_record_payload_sizes(pkt);
+    if sizes.is_empty() {
+        out.push(payload);
+        return out;
+    }
+
+    for size in sizes {
+        if size == CHECK_MARK {
+            if payload.is_empty() {
+                break;
+            }
+            continue;
+        }
+        let size = size as usize;
+        if payload.len() > size {
+            out.push(payload.drain(..size).collect());
+        } else if !payload.is_empty() {
+            let mut chunk = std::mem::take(&mut payload);
+            let padding_len = size.saturating_sub(chunk.len() + HEADER_LEN);
+            if padding_len > 0 {
+                chunk.extend_from_slice(&encode_waste_frame(padding_len));
+            }
+            out.push(chunk);
+        } else {
+            out.push(encode_waste_frame(size));
+        }
+    }
+
+    if !payload.is_empty() {
+        out.push(payload);
+    }
+    if out.is_empty() {
+        out.push(Vec::new());
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rd_interface::IntoAddress;
+    use sha2::Digest;
+
+    #[test]
+    fn frame_header_is_command_stream_id_and_big_endian_length() {
+        let bytes = encode_frame(&Frame {
+            cmd: CMD_PSH,
+            sid: 0x01020304,
+            data: b"abc".to_vec(),
+        });
+        assert_eq!(bytes, vec![2, 1, 2, 3, 4, 0, 3, b'a', b'b', b'c']);
+        assert_eq!(
+            decode_header(bytes[..HEADER_LEN].try_into().unwrap()),
+            (CMD_PSH, 0x01020304, 3)
+        );
+    }
+
+    #[test]
+    fn target_address_uses_socks_addr_port_serialization() {
+        let domain = "example.com:443".into_address().unwrap();
+        assert_eq!(
+            encode_socks_addr(&domain).unwrap(),
+            b"\x03\x0bexample.com\x01\xbb".to_vec()
+        );
+
+        let ip = "127.0.0.1:80".into_address().unwrap();
+        assert_eq!(
+            encode_socks_addr(&ip).unwrap(),
+            vec![1, 127, 0, 0, 1, 0, 80]
+        );
+    }
+
+    #[test]
+    fn settings_are_string_map_with_v2_and_padding_md5() {
+        let padding = PaddingScheme::default();
+        let settings = encode_settings(&padding);
+        let text = std::str::from_utf8(&settings).unwrap();
+        assert!(text.contains("v=2"));
+        assert!(text.contains("padding-md5="));
+        assert!(text.contains(&padding.md5_hex()));
+    }
+
+    #[test]
+    fn auth_prefix_is_sha256_password_plus_padding0() {
+        let padding = PaddingScheme::parse(b"stop=1\n0=4-4").unwrap();
+        let prefix = auth_prefix("password", &padding);
+        assert_eq!(&prefix[..32], &sha2::Sha256::digest(b"password")[..]);
+        assert_eq!(&prefix[32..34], &[0, 4]);
+        assert_eq!(&prefix[34..], &[0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn apply_padding_splits_payload_and_adds_waste() {
+        let padding = PaddingScheme::parse(b"stop=3\n1=20-20,c,20-20\n2=20-20").unwrap();
+        assert_eq!(apply_padding(1, &padding, b"hello".to_vec())[0].len(), 20);
+        let split = apply_padding(2, &padding, vec![1; 30]);
+        assert_eq!(split.len(), 2);
+        assert_eq!(split[0].len(), 20);
+        assert_eq!(split[1].len(), 10);
+    }
+}

--- a/scripts/interop.Dockerfile
+++ b/scripts/interop.Dockerfile
@@ -1,0 +1,53 @@
+FROM rust:1-bookworm
+
+ARG TARGETARCH
+ARG ANYTLS_VERSION=0.0.12
+ARG HYSTERIA_VERSION=2.8.2
+ARG SHADOWSOCKS_RUST_VERSION=1.24.0
+ARG TROJAN_VERSION=1.16.0
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl unzip jq netcat-openbsd openssl python3 xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    xray_version="$(curl -fsSL https://api.github.com/repos/XTLS/Xray-core/releases/latest | jq -r .tag_name)"; \
+    case "${TARGETARCH}" in \
+      amd64) xray_arch=64; anytls_arch=linux_amd64; hysteria_arch=linux-amd64; ss_arch=x86_64-unknown-linux-gnu; trojan_arch=linux-amd64 ;; \
+      arm64) xray_arch=arm64-v8a; anytls_arch=linux_arm64; hysteria_arch=linux-arm64; ss_arch=aarch64-unknown-linux-gnu; trojan_arch= ;; \
+      *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL -o /tmp/xray.zip "https://github.com/XTLS/Xray-core/releases/download/${xray_version}/Xray-linux-${xray_arch}.zip"; \
+    unzip -q /tmp/xray.zip -d /tmp/xray; \
+    install -m 0755 /tmp/xray/xray /usr/local/bin/xray; \
+    rm -rf /tmp/xray /tmp/xray.zip; \
+    curl -fsSL -o /tmp/anytls.zip "https://github.com/anytls/anytls-go/releases/download/v${ANYTLS_VERSION}/anytls_${ANYTLS_VERSION}_${anytls_arch}.zip"; \
+    unzip -q /tmp/anytls.zip -d /tmp/anytls; \
+    install -m 0755 /tmp/anytls/anytls-server /usr/local/bin/anytls-server; \
+    if [ -f /tmp/anytls/anytls-client ]; then install -m 0755 /tmp/anytls/anytls-client /usr/local/bin/anytls-client; fi; \
+    rm -rf /tmp/anytls /tmp/anytls.zip; \
+    curl -fsSL -o /usr/local/bin/hysteria "https://github.com/apernet/hysteria/releases/download/app/v${HYSTERIA_VERSION}/hysteria-${hysteria_arch}"; \
+    chmod +x /usr/local/bin/hysteria; \
+    curl -fsSL -o /tmp/shadowsocks.tar.xz "https://github.com/shadowsocks/shadowsocks-rust/releases/download/v${SHADOWSOCKS_RUST_VERSION}/shadowsocks-v${SHADOWSOCKS_RUST_VERSION}.${ss_arch}.tar.xz"; \
+    tar -xJf /tmp/shadowsocks.tar.xz -C /tmp; \
+    install -m 0755 /tmp/ssserver /usr/local/bin/ssserver; \
+    install -m 0755 /tmp/sslocal /usr/local/bin/sslocal; \
+    rm -f /tmp/shadowsocks.tar.xz /tmp/ssserver /tmp/sslocal; \
+    if [ -n "$trojan_arch" ]; then \
+      curl -fsSL -o /tmp/trojan.tar.xz "https://github.com/trojan-gfw/trojan/releases/download/v${TROJAN_VERSION}/trojan-${TROJAN_VERSION}-${trojan_arch}.tar.xz"; \
+      mkdir -p /tmp/trojan; \
+      tar -xJf /tmp/trojan.tar.xz -C /tmp/trojan --strip-components=1; \
+      install -m 0755 /tmp/trojan/trojan /usr/local/bin/trojan; \
+      rm -rf /tmp/trojan /tmp/trojan.tar.xz; \
+    fi
+
+RUN set -eux; \
+    ssserver --version; \
+    sslocal --version; \
+    xray version; \
+    hysteria version; \
+    if command -v trojan >/dev/null 2>&1; then trojan --version; fi; \
+    anytls-server --help >/dev/null || true
+
+WORKDIR /workspace

--- a/scripts/protocol_interop_e2e.sh
+++ b/scripts/protocol_interop_e2e.sh
@@ -1,0 +1,400 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RDP_BIN="${RDP_BIN:-$ROOT_DIR/target/debug/rabbit-digger-pro}"
+PROTOCOL="${1:-${PROTOCOL:-all}}"
+TMP_DIR="$(mktemp -d /tmp/rdp-protocol-interop.XXXXXX)"
+PIDS=()
+
+cleanup() {
+  local status="$?"
+  for pid in "${PIDS[@]:-}"; do
+    kill "$pid" >/dev/null 2>&1 || true
+    wait "$pid" >/dev/null 2>&1 || true
+  done
+  if [[ "${KEEP_TMP:-0}" == "1" || "$status" -ne 0 ]]; then
+    echo "preserved logs and configs: $TMP_DIR" >&2
+  else
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "missing required command: $1" >&2
+    exit 1
+  }
+}
+
+pick_port() {
+  python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+}
+
+wait_port() {
+  local port="$1"
+  for _ in $(seq 1 200); do
+    if nc -z 127.0.0.1 "$port" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "port did not open: $port" >&2
+  return 1
+}
+
+wait_http_ok() {
+  local port="$1"
+  for _ in $(seq 1 200); do
+    if curl -fsS --max-time 2 "http://127.0.0.1:$port/small.txt" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  echo "http test server did not become ready: $port" >&2
+  return 1
+}
+
+start_bg() {
+  local log_file="$1"
+  shift
+  "$@" >"$log_file" 2>&1 &
+  local pid="$!"
+  PIDS+=("$pid")
+  echo "$pid"
+}
+
+stop_bg() {
+  local pid="$1"
+  kill "$pid" >/dev/null 2>&1 || true
+  wait "$pid" >/dev/null 2>&1 || true
+}
+
+curl_via_socks() {
+  local proxy_port="$1"
+  local out="$2"
+  curl -fsS --max-time 20 --proxy "socks5h://127.0.0.1:$proxy_port" \
+    "http://127.0.0.1:$HTTP_PORT/small.txt" >"$out"
+  cmp -s "$TMP_DIR/www/small.txt" "$out"
+}
+
+make_rdp_client_config() {
+  local type="$1" server_port="$2" socks_port="$3" extra="$4"
+  cat >"$TMP_DIR/rdp-${type}-client.yaml" <<EOF_CFG
+id: rdp-${type}-client
+net:
+  upstream:
+    type: ${type}
+    server: 127.0.0.1:${server_port}
+${extra}
+server:
+  mixed:
+    type: http+socks5
+    bind: 127.0.0.1:${socks_port}
+    net: upstream
+EOF_CFG
+}
+
+make_rdp_server_config() {
+  local type="$1" listen_port="$2" extra="$3"
+  cat >"$TMP_DIR/rdp-${type}-server.yaml" <<EOF_CFG
+id: rdp-${type}-server
+net: {}
+server:
+  inbound:
+    type: ${type}
+    bind: 127.0.0.1:${listen_port}
+${extra}
+EOF_CFG
+}
+
+run_shadowsocks() {
+  need_cmd ssserver
+  need_cmd sslocal
+  local server_port rdp_socks_port rdp_server_port official_socks_port
+  server_port="$(pick_port)"
+  rdp_socks_port="$(pick_port)"
+  rdp_server_port="$(pick_port)"
+  official_socks_port="$(pick_port)"
+
+  echo "shadowsocks scenario 1: RDP client -> official server"
+  local ss_server_pid
+  ss_server_pid="$(start_bg "$TMP_DIR/ss-official-server.log" ssserver \
+    -s "127.0.0.1:${server_port}" -m aes-128-gcm -k testpass)"
+  wait_port "$server_port"
+  make_rdp_client_config shadowsocks "$server_port" "$rdp_socks_port" "    password: testpass
+    cipher: aes-128-gcm"
+  local rdp_client_pid
+  rdp_client_pid="$(start_bg "$TMP_DIR/ss-rdp-client.log" "$RDP_BIN" -c "$TMP_DIR/rdp-shadowsocks-client.yaml")"
+  wait_port "$rdp_socks_port"
+  curl_via_socks "$rdp_socks_port" "$TMP_DIR/ss-scenario1.txt"
+  stop_bg "$rdp_client_pid"
+  stop_bg "$ss_server_pid"
+
+  echo "shadowsocks scenario 2: official client -> RDP server"
+  make_rdp_server_config shadowsocks "$rdp_server_port" "    password: testpass
+    cipher: aes-128-gcm"
+  local rdp_server_pid official_client_pid
+  rdp_server_pid="$(start_bg "$TMP_DIR/ss-rdp-server.log" "$RDP_BIN" -c "$TMP_DIR/rdp-shadowsocks-server.yaml")"
+  wait_port "$rdp_server_port"
+  official_client_pid="$(start_bg "$TMP_DIR/ss-official-client.log" sslocal \
+    -b "127.0.0.1:${official_socks_port}" -s "127.0.0.1:${rdp_server_port}" -m aes-128-gcm -k testpass)"
+  wait_port "$official_socks_port"
+  curl_via_socks "$official_socks_port" "$TMP_DIR/ss-scenario2.txt"
+  stop_bg "$official_client_pid"
+  stop_bg "$rdp_server_pid"
+}
+
+run_trojan() {
+  need_cmd trojan
+  local trojan_server_port rdp_socks_port
+  trojan_server_port="$(pick_port)"
+  rdp_socks_port="$(pick_port)"
+
+  openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+    -keyout "$TMP_DIR/trojan.key" -out "$TMP_DIR/trojan.crt" -subj '/CN=localhost' >/dev/null 2>&1
+
+  cat >"$TMP_DIR/trojan-server.json" <<EOF_CFG
+{
+  "run_type": "server",
+  "local_addr": "127.0.0.1",
+  "local_port": ${trojan_server_port},
+  "remote_addr": "127.0.0.1",
+  "remote_port": ${HTTP_PORT},
+  "password": ["testpass"],
+  "log_level": 1,
+  "ssl": {
+    "cert": "${TMP_DIR}/trojan.crt",
+    "key": "${TMP_DIR}/trojan.key"
+  }
+}
+EOF_CFG
+
+  echo "trojan scenario 1: RDP client -> official server"
+  local trojan_server_pid rdp_client_pid
+  trojan_server_pid="$(start_bg "$TMP_DIR/trojan-official-server.log" trojan "$TMP_DIR/trojan-server.json")"
+  wait_port "$trojan_server_port"
+  make_rdp_client_config trojan "$trojan_server_port" "$rdp_socks_port" "    password: testpass
+    sni: localhost
+    skip_cert_verify: true"
+  rdp_client_pid="$(start_bg "$TMP_DIR/trojan-rdp-client.log" "$RDP_BIN" -c "$TMP_DIR/rdp-trojan-client.yaml")"
+  wait_port "$rdp_socks_port"
+  curl_via_socks "$rdp_socks_port" "$TMP_DIR/trojan-scenario1.txt"
+  stop_bg "$rdp_client_pid"
+  stop_bg "$trojan_server_pid"
+}
+
+run_anytls() {
+  need_cmd anytls-server
+  local server_port rdp_socks_port
+  server_port="$(pick_port)"
+  rdp_socks_port="$(pick_port)"
+
+  echo "anytls scenario 1: RDP client -> official server"
+  local anytls_server_pid
+  anytls_server_pid="$(start_bg "$TMP_DIR/anytls-official-server.log" anytls-server \
+    -l "127.0.0.1:${server_port}" -p testpass)"
+  wait_port "$server_port"
+  make_rdp_client_config anytls "$server_port" "$rdp_socks_port" "    password: testpass
+    sni: localhost
+    skip_cert_verify: true"
+  local rdp_client_pid
+  rdp_client_pid="$(start_bg "$TMP_DIR/anytls-rdp-client.log" "$RDP_BIN" -c "$TMP_DIR/rdp-anytls-client.yaml")"
+  wait_port "$rdp_socks_port"
+  curl_via_socks "$rdp_socks_port" "$TMP_DIR/anytls-scenario1.txt"
+  stop_bg "$rdp_client_pid"
+  stop_bg "$anytls_server_pid"
+}
+
+run_vless() {
+  need_cmd xray
+  local xray_server_port rdp_socks_port rdp_server_port official_socks_port
+  xray_server_port="$(pick_port)"
+  rdp_socks_port="$(pick_port)"
+  rdp_server_port="$(pick_port)"
+  official_socks_port="$(pick_port)"
+
+  local x25519_output private_key public_key
+  x25519_output="$(xray x25519)"
+  private_key="$(printf '%s\n' "$x25519_output" | sed -n 's/^PrivateKey: //p')"
+  public_key="$(printf '%s\n' "$x25519_output" | sed -n 's/^Password (PublicKey): //p')"
+  test -n "$private_key"
+  test -n "$public_key"
+
+  cat >"$TMP_DIR/xray-vless-server.json" <<EOF_CFG
+{
+  "log": { "loglevel": "warning" },
+  "inbounds": [{
+    "listen": "127.0.0.1",
+    "port": ${xray_server_port},
+    "protocol": "vless",
+    "settings": { "clients": [{ "id": "27848739-7e61-4ea0-ba56-d8edf2587d12", "flow": "xtls-rprx-vision" }], "decryption": "none" },
+    "streamSettings": {
+      "network": "tcp",
+      "security": "reality",
+      "realitySettings": {
+        "dest": "www.microsoft.com:443",
+        "serverNames": ["www.microsoft.com"],
+        "privateKey": "${private_key}",
+        "shortIds": ["00000000"]
+      }
+    }
+  }],
+  "outbounds": [{ "protocol": "freedom" }]
+}
+EOF_CFG
+
+  cat >"$TMP_DIR/rdp-vless-client.yaml" <<EOF_CFG
+id: rdp-vless-client
+net:
+  upstream:
+    type: vless
+    server: 127.0.0.1:${xray_server_port}
+    id: 27848739-7e61-4ea0-ba56-d8edf2587d12
+    flow: xtls-rprx-vision
+    sni: www.microsoft.com
+    client_fingerprint: chrome
+    reality_public_key: ${public_key}
+    reality_short_id: "00000000"
+server:
+  mixed:
+    type: http+socks5
+    bind: 127.0.0.1:${rdp_socks_port}
+    net: upstream
+EOF_CFG
+
+  echo "vless scenario 1: RDP client -> official Xray server"
+  local xray_server_pid rdp_client_pid
+  xray_server_pid="$(start_bg "$TMP_DIR/vless-xray-server.log" xray run -c "$TMP_DIR/xray-vless-server.json")"
+  wait_port "$xray_server_port"
+  rdp_client_pid="$(start_bg "$TMP_DIR/vless-rdp-client.log" "$RDP_BIN" -c "$TMP_DIR/rdp-vless-client.yaml")"
+  wait_port "$rdp_socks_port"
+  curl_via_socks "$rdp_socks_port" "$TMP_DIR/vless-scenario1.txt"
+  stop_bg "$rdp_client_pid"
+  stop_bg "$xray_server_pid"
+
+  echo "vless scenario 2: official Xray client -> RDP server"
+  make_rdp_server_config vless "$rdp_server_port" "    id: 27848739-7e61-4ea0-ba56-d8edf2587d12
+    flow: xtls-rprx-vision
+    reality_server_name: www.microsoft.com
+    reality_private_key: ${private_key}
+    reality_short_id: \"00000000\""
+  cat >"$TMP_DIR/xray-vless-client.json" <<EOF_CFG
+{
+  "log": { "loglevel": "warning" },
+  "inbounds": [{ "listen": "127.0.0.1", "port": ${official_socks_port}, "protocol": "socks", "settings": { "udp": false } }],
+  "outbounds": [{
+    "protocol": "vless",
+    "settings": { "vnext": [{ "address": "127.0.0.1", "port": ${rdp_server_port}, "users": [{ "id": "27848739-7e61-4ea0-ba56-d8edf2587d12", "encryption": "none", "flow": "xtls-rprx-vision" }] }] },
+    "streamSettings": { "network": "tcp", "security": "reality", "realitySettings": { "serverName": "www.microsoft.com", "fingerprint": "chrome", "publicKey": "${public_key}", "shortId": "00000000" } }
+  }]
+}
+EOF_CFG
+  local rdp_server_pid xray_client_pid
+  rdp_server_pid="$(start_bg "$TMP_DIR/vless-rdp-server.log" "$RDP_BIN" -c "$TMP_DIR/rdp-vless-server.yaml")"
+  wait_port "$rdp_server_port"
+  xray_client_pid="$(start_bg "$TMP_DIR/vless-xray-client.log" xray run -c "$TMP_DIR/xray-vless-client.json")"
+  wait_port "$official_socks_port"
+  curl_via_socks "$official_socks_port" "$TMP_DIR/vless-scenario2.txt"
+  stop_bg "$xray_client_pid"
+  stop_bg "$rdp_server_pid"
+}
+
+run_hysteria() {
+  need_cmd hysteria
+  local official_server_port rdp_socks_port rdp_server_port official_socks_port
+  official_server_port="$(pick_port)"
+  rdp_socks_port="$(pick_port)"
+  rdp_server_port="$(pick_port)"
+  official_socks_port="$(pick_port)"
+
+  openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+    -keyout "$TMP_DIR/server.key" -out "$TMP_DIR/server.crt" -subj '/CN=localhost' >/dev/null 2>&1
+
+  cat >"$TMP_DIR/hysteria-official-server.yaml" <<EOF_CFG
+listen: 127.0.0.1:${official_server_port}
+tls:
+  cert: ${TMP_DIR}/server.crt
+  key: ${TMP_DIR}/server.key
+auth:
+  type: password
+  password: testpass
+EOF_CFG
+
+  echo "hysteria scenario 1: RDP client -> official server"
+  local official_server_pid rdp_client_pid
+  official_server_pid="$(start_bg "$TMP_DIR/hysteria-official-server.log" hysteria server -c "$TMP_DIR/hysteria-official-server.yaml")"
+  sleep 1
+  make_rdp_client_config hysteria "$official_server_port" "$rdp_socks_port" "    auth: testpass
+    server_name: localhost
+    ca_pem: |
+$(sed 's/^/      /' "$TMP_DIR/server.crt")"
+  rdp_client_pid="$(start_bg "$TMP_DIR/hysteria-rdp-client.log" "$RDP_BIN" -c "$TMP_DIR/rdp-hysteria-client.yaml")"
+  wait_port "$rdp_socks_port"
+  curl_via_socks "$rdp_socks_port" "$TMP_DIR/hysteria-scenario1.txt"
+  stop_bg "$rdp_client_pid"
+  stop_bg "$official_server_pid"
+
+  echo "hysteria scenario 2: official client -> RDP server"
+  make_rdp_server_config hysteria "$rdp_server_port" "    tls_cert: ${TMP_DIR}/server.crt
+    tls_key: ${TMP_DIR}/server.key
+    auth: testpass"
+  cat >"$TMP_DIR/hysteria-official-client.yaml" <<EOF_CFG
+server: 127.0.0.1:${rdp_server_port}
+auth: testpass
+tls:
+  sni: localhost
+  insecure: true
+socks5:
+  listen: 127.0.0.1:${official_socks_port}
+EOF_CFG
+  local rdp_server_pid official_client_pid
+  rdp_server_pid="$(start_bg "$TMP_DIR/hysteria-rdp-server.log" "$RDP_BIN" -c "$TMP_DIR/rdp-hysteria-server.yaml")"
+  sleep 1
+  official_client_pid="$(start_bg "$TMP_DIR/hysteria-official-client.log" hysteria client -c "$TMP_DIR/hysteria-official-client.yaml")"
+  wait_port "$official_socks_port"
+  curl_via_socks "$official_socks_port" "$TMP_DIR/hysteria-scenario2.txt"
+  stop_bg "$official_client_pid"
+  stop_bg "$rdp_server_pid"
+}
+
+need_cmd cargo
+need_cmd curl
+need_cmd nc
+need_cmd python3
+need_cmd openssl
+
+HTTP_PORT="$(pick_port)"
+mkdir -p "$TMP_DIR/www"
+printf 'rabbit-digger-pro protocol interop payload\n' >"$TMP_DIR/www/small.txt"
+http_pid="$(start_bg "$TMP_DIR/http.log" python3 -m http.server "$HTTP_PORT" --bind 127.0.0.1 --directory "$TMP_DIR/www")"
+wait_http_ok "$HTTP_PORT"
+
+echo "building rabbit-digger-pro..."
+cargo build --quiet --bin rabbit-digger-pro --manifest-path "$ROOT_DIR/Cargo.toml"
+
+case "$PROTOCOL" in
+  all)
+    run_shadowsocks
+    run_trojan
+    run_vless
+    run_hysteria
+    run_anytls
+    ;;
+  shadowsocks|ss) run_shadowsocks ;;
+  trojan) run_trojan ;;
+  vless) run_vless ;;
+  hysteria) run_hysteria ;;
+  anytls) run_anytls ;;
+  *) echo "unknown protocol: $PROTOCOL" >&2; exit 2 ;;
+esac
+
+stop_bg "$http_pid"
+echo "protocol interop passed: $PROTOCOL"

--- a/scripts/protocol_interop_e2e.sh
+++ b/scripts/protocol_interop_e2e.sh
@@ -316,7 +316,18 @@ run_hysteria() {
   official_socks_port="$(pick_port)"
 
   openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
-    -keyout "$TMP_DIR/server.key" -out "$TMP_DIR/server.crt" -subj '/CN=localhost' >/dev/null 2>&1
+    -keyout "$TMP_DIR/ca.key" -out "$TMP_DIR/ca.crt" -subj '/CN=rdp-hysteria-test-ca' \
+    -addext 'basicConstraints=critical,CA:TRUE' >/dev/null 2>&1
+  openssl req -newkey rsa:2048 -nodes \
+    -keyout "$TMP_DIR/server.key" -out "$TMP_DIR/server.csr" -subj '/CN=localhost' >/dev/null 2>&1
+  cat >"$TMP_DIR/server.ext" <<EOF_EXT
+basicConstraints=critical,CA:FALSE
+keyUsage=critical,digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1
+EOF_EXT
+  openssl x509 -req -in "$TMP_DIR/server.csr" -CA "$TMP_DIR/ca.crt" -CAkey "$TMP_DIR/ca.key" \
+    -CAcreateserial -days 1 -out "$TMP_DIR/server.crt" -extfile "$TMP_DIR/server.ext" >/dev/null 2>&1
 
   cat >"$TMP_DIR/hysteria-official-server.yaml" <<EOF_CFG
 listen: 127.0.0.1:${official_server_port}
@@ -334,8 +345,7 @@ EOF_CFG
   sleep 1
   make_rdp_client_config hysteria "$official_server_port" "$rdp_socks_port" "    auth: testpass
     server_name: localhost
-    ca_pem: |
-$(sed 's/^/      /' "$TMP_DIR/server.crt")"
+    ca_pem: ${TMP_DIR}/ca.crt"
   rdp_client_pid="$(start_bg "$TMP_DIR/hysteria-rdp-client.log" "$RDP_BIN" -c "$TMP_DIR/rdp-hysteria-client.yaml")"
   wait_port "$rdp_socks_port"
   curl_via_socks "$rdp_socks_port" "$TMP_DIR/hysteria-scenario1.txt"

--- a/src/config/importer/clash.rs
+++ b/src/config/importer/clash.rs
@@ -291,6 +291,32 @@ impl Clash {
 
                 with_net(Net::new("vless", opt), target_net)
             }
+            "anytls" => {
+                #[derive(Debug, Deserialize)]
+                #[serde(rename_all = "kebab-case")]
+                struct Param {
+                    server: String,
+                    port: PortValue,
+                    password: String,
+                    sni: Option<String>,
+                    #[serde(rename = "skip-cert-verify")]
+                    skip_cert_verify: Option<bool>,
+                }
+                let params: Param = serde_json::from_value(p.opt)?;
+                let port = params.port.into_u16()?;
+                with_net(
+                    Net::new(
+                        "anytls",
+                        json!({
+                            "server": format!("{}:{}", params.server, port),
+                            "password": params.password,
+                            "sni": params.sni.unwrap_or(params.server),
+                            "skip_cert_verify": params.skip_cert_verify.unwrap_or_default(),
+                        }),
+                    ),
+                    target_net,
+                )
+            }
             "http" => {
                 #[derive(Debug, Deserialize)]
                 struct Param {
@@ -827,6 +853,35 @@ mod tests {
                 .get("reality_short_id")
                 .and_then(|v| v.as_str()),
             Some("00000000")
+        );
+
+        let anytls: Proxy = serde_json::from_value(serde_json::json!({
+            "name": "a",
+            "type": "anytls",
+            "server": "example.com",
+            "port": 443,
+            "password": "secret",
+            "sni": "www.example.com",
+            "skip-cert-verify": true
+        }))
+        .unwrap();
+        let anytls = c.proxy_to_net(anytls, None).unwrap();
+        assert_eq!(anytls.net_type, "anytls");
+        assert_eq!(
+            anytls.opt.get("server").and_then(|v| v.as_str()),
+            Some("example.com:443")
+        );
+        assert_eq!(
+            anytls.opt.get("password").and_then(|v| v.as_str()),
+            Some("secret")
+        );
+        assert_eq!(
+            anytls.opt.get("sni").and_then(|v| v.as_str()),
+            Some("www.example.com")
+        );
+        assert_eq!(
+            anytls.opt.get("skip_cert_verify").and_then(|v| v.as_bool()),
+            Some(true)
         );
 
         let http: Proxy = serde_json::from_value(serde_json::json!({

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@ pub fn get_registry() -> Result<Registry> {
     registry.init_with_registry("hysteria", hysteria::init)?;
     #[cfg(feature = "vless")]
     registry.init_with_registry("vless", vless::init)?;
+    #[cfg(feature = "anytls")]
+    registry.init_with_registry("anytls", anytls::init)?;
 
     registry.init_with_registry("rabbit-digger-pro", select::init)?;
 


### PR DESCRIPTION
## Summary
- add AnyTLS outbound protocol crate and registry feature
- implement TLS + AnyTLS session framing for TCP outbound
- implement protocol padding/feature hiding: padding0 auth padding, session packet padding/splitting, cmdWaste, and cmdUpdatePaddingScheme handling
- batch cmdSettings + initial cmdSYN + target cmdPSH into session packet 1 per protocol
- support Clash/Mihomo `type: anytls` import

## Test Plan
- `cargo test -p anytls -- --nocapture`
- `cargo test config::importer::clash::tests:: -- --nocapture`
- `cargo test --workspace`
- official anytls-go v0.0.12 interop with padding enabled: `anytls-server -l 127.0.0.1:28443 -p testpass`, RDP mixed socks over anytls, `curl -x socks5h://127.0.0.1:28081 http://127.0.0.1:28080/` returned HTTP 200

Note: `cargo test --workspace --all-features` currently fails before this change because rd-std enables multiple TLS backends and defines `backend` multiple times.