### PR TITLE
feat: add Steam Deck Decky release flow

### DIFF
--- a/.github/workflows/steamdeck-release.yml
+++ b/.github/workflows/steamdeck-release.yml
@@ -1,6 +1,8 @@
 name: Steam Deck Release Assets
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:
@@ -35,12 +37,54 @@ jobs:
         with:
           version: 10.33.3
 
+      - name: Resolve release metadata
+        id: release
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_CHANNEL: ${{ github.event.inputs.channel }}
+          INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "release" ]; then
+            release_tag="$RELEASE_TAG"
+            version="${release_tag#v}"
+            if [ "$RELEASE_PRERELEASE" = "true" ]; then
+              channel="prerelease"
+            else
+              channel="stable"
+            fi
+            upload_assets="true"
+          else
+            version="$INPUT_VERSION"
+            channel="$INPUT_CHANNEL"
+            release_tag="$INPUT_RELEASE_TAG"
+            upload_assets="false"
+            if [ -n "$release_tag" ]; then
+              upload_assets="true"
+            else
+              release_tag="v$version"
+            fi
+          fi
+
+          {
+            echo "version=$version"
+            echo "channel=$channel"
+            echo "release_tag=$release_tag"
+            echo "upload_assets=$upload_assets"
+            echo "release_base_url=https://github.com/${{ github.repository }}/releases/download/$release_tag"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build Steam Deck assets
         run: scripts/build-steamdeck-release.sh
         env:
-          RDP_VERSION: ${{ inputs.version }}
-          RDP_CHANNEL: ${{ inputs.channel }}
-          RDP_RELEASE_BASE_URL: https://github.com/${{ github.repository }}/releases/download/${{ inputs.release_tag || format('v{0}', inputs.version) }}
+          RDP_VERSION: ${{ steps.release.outputs.version }}
+          RDP_CHANNEL: ${{ steps.release.outputs.channel }}
+          RDP_RELEASE_BASE_URL: ${{ steps.release.outputs.release_base_url }}
 
       - uses: actions/upload-artifact@v4
         with:
@@ -48,7 +92,7 @@ jobs:
           path: dist/steamdeck/*
 
       - name: Upload assets to GitHub release
-        if: inputs.release_tag != ''
-        run: gh release upload "${{ inputs.release_tag }}" dist/steamdeck/* --clobber
+        if: steps.release.outputs.upload_assets == 'true'
+        run: gh release upload "${{ steps.release.outputs.release_tag }}" dist/steamdeck/* --clobber
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/steamdeck-release.yml
+++ b/.github/workflows/steamdeck-release.yml
@@ -1,0 +1,54 @@
+name: Steam Deck Release Assets
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version used in the Steam Deck update manifest"
+        required: true
+        default: "0.1.0"
+      channel:
+        description: "Update channel"
+        required: true
+        default: "dev"
+      release_tag:
+        description: "Optional GitHub release tag to upload assets to, for example v0.1.0"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.3
+
+      - name: Build Steam Deck assets
+        run: scripts/build-steamdeck-release.sh
+        env:
+          RDP_VERSION: ${{ inputs.version }}
+          RDP_CHANNEL: ${{ inputs.channel }}
+          RDP_RELEASE_BASE_URL: https://github.com/${{ github.repository }}/releases/download/${{ inputs.release_tag || format('v{0}', inputs.version) }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: steamdeck-release-assets
+          path: dist/steamdeck/*
+
+      - name: Upload assets to GitHub release
+        if: inputs.release_tag != ''
+        run: gh release upload "${{ inputs.release_tag }}" dist/steamdeck/* --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.rd.yml
 *.dat
 *.log
+*.pyc
+__pycache__/
 dist/
 node_modules/
 docs/node_modules/

--- a/packaging/decky/README.md
+++ b/packaging/decky/README.md
@@ -19,6 +19,13 @@ The script writes these files to `dist/steamdeck/`:
 - `rabbit-digger-pro-decky.zip`
 - `steamdeck-update-manifest.json`
 
+When a GitHub Release is published, the `Steam Deck Release Assets` workflow
+builds these assets automatically and uploads them to that release. The Decky
+plugin checks the release manifest at `releases/latest/download`, so publishing a
+new stable release is what makes the Quick Access Menu update button pick up a
+new version. The workflow can also be run manually with a `release_tag` to upload
+assets to an existing release.
+
 ## Install On Steam Deck
 
 The bootstrap installer consumes the manifest and installs both the host helper

--- a/packaging/decky/README.md
+++ b/packaging/decky/README.md
@@ -1,0 +1,49 @@
+# Steam Deck Decky Package
+
+This directory contains the Decky Loader plugin used by the Steam Deck bootstrap
+and update flow.
+
+## Build Release Assets
+
+Run from the repository root on Linux:
+
+```bash
+RDP_VERSION=0.1.0 \
+RDP_CHANNEL=dev \
+scripts/build-steamdeck-release.sh
+```
+
+The script writes these files to `dist/steamdeck/`:
+
+- `rabbit-digger-pro-x86_64-unknown-linux-gnu`
+- `rabbit-digger-pro-decky.zip`
+- `steamdeck-update-manifest.json`
+
+## Install On Steam Deck
+
+The bootstrap installer consumes the manifest and installs both the host helper
+and the Decky plugin. If Decky Loader is missing, the installer tries Decky's
+official release installer first. If GitHub is unreachable from the Steam Deck,
+the Rabbit Digger Pro helper and plugin files are still installed; install Decky
+Loader later and it can pick up the staged plugin.
+
+```bash
+RDP_MANIFEST_URL=https://github.com/spacemeowx2/rabbit-digger-pro/releases/latest/download/steamdeck-update-manifest.json \
+scripts/install-steamdeck.sh
+```
+
+After bootstrap, normal updates should be done from the Decky Quick Access Menu.
+
+Set `RDP_SKIP_DECKY_INSTALL=1` to skip Decky Loader auto-install. Set
+`RDP_REQUIRE_DECKY=1` if the bootstrap should fail when Decky Loader is missing.
+
+## Uninstall From Steam Deck
+
+The same bootstrap script can remove Rabbit Digger Pro's user service, helper
+binary, Decky plugin, token, and update config:
+
+```bash
+scripts/install-steamdeck.sh uninstall
+```
+
+Decky Loader itself is left installed because it may be shared by other plugins.

--- a/packaging/decky/rabbit-digger-pro/main.py
+++ b/packaging/decky/rabbit-digger-pro/main.py
@@ -1,0 +1,279 @@
+import hashlib
+import json
+import os
+import pwd
+import secrets
+import shutil
+import subprocess
+import tempfile
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Any
+
+
+PLUGIN_DIR = Path(__file__).resolve().parent
+SERVICE_UNIT = "rabbit-digger-pro.service"
+DEFAULT_BIND = "127.0.0.1:9091"
+DEFAULT_MANIFEST_URL = (
+    "https://github.com/spacemeowx2/rabbit-digger-pro/releases/latest/download/"
+    "steamdeck-update-manifest.json"
+)
+
+
+def _user_home() -> Path:
+    value = os.environ.get("DECKY_USER_HOME") or os.environ.get("HOME")
+    return Path(value or "/home/deck")
+
+
+def _xdg_data_home() -> Path:
+    if os.environ.get("DECKY_USER_HOME"):
+        return _user_home() / ".local/share"
+    return Path(os.environ.get("XDG_DATA_HOME", _user_home() / ".local/share"))
+
+
+def _xdg_config_home() -> Path:
+    if os.environ.get("DECKY_USER_HOME"):
+        return _user_home() / ".config"
+    return Path(os.environ.get("XDG_CONFIG_HOME", _user_home() / ".config"))
+
+
+def _data_dir() -> Path:
+    return _xdg_data_home() / "rabbit_digger_pro"
+
+
+def _config_dir() -> Path:
+    return _xdg_config_home() / "rabbit_digger_pro"
+
+
+def _helper_binary() -> Path:
+    return _data_dir() / "helper" / "rabbit-digger-pro"
+
+
+def _token_path() -> Path:
+    return _data_dir() / "decky-token"
+
+
+def _update_config_path() -> Path:
+    return _config_dir() / "decky-update.json"
+
+
+def _plugin_version() -> str:
+    package_json = PLUGIN_DIR / "package.json"
+    try:
+        return json.loads(package_json.read_text()).get("version", "0.0.0")
+    except Exception:
+        return "0.0.0"
+
+
+def _load_update_config() -> dict[str, Any]:
+    config_path = _update_config_path()
+    if not config_path.exists():
+        return {"manifest_url": DEFAULT_MANIFEST_URL}
+    try:
+        config = json.loads(config_path.read_text())
+    except Exception:
+        return {"manifest_url": DEFAULT_MANIFEST_URL}
+    config.setdefault("manifest_url", DEFAULT_MANIFEST_URL)
+    return config
+
+
+def _ensure_token() -> str:
+    token_path = _token_path()
+    token_path.parent.mkdir(parents=True, exist_ok=True)
+    if token_path.exists():
+        return token_path.read_text().strip()
+    token = secrets.token_urlsafe(32)
+    token_path.write_text(token)
+    token_path.chmod(0o600)
+    return token
+
+
+def _deck_user() -> tuple[str, int]:
+    try:
+        info = pwd.getpwnam("deck")
+        return info.pw_name, info.pw_uid
+    except KeyError:
+        return pwd.getpwuid(os.getuid()).pw_name, os.getuid()
+
+
+def _run_as_deck(args: list[str], timeout: int = 60) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    _, uid = _deck_user()
+    env["XDG_RUNTIME_DIR"] = f"/run/user/{uid}"
+    env["DBUS_SESSION_BUS_ADDRESS"] = f"unix:path=/run/user/{uid}/bus"
+
+    command = args
+    if os.geteuid() == 0:
+        user, _ = _deck_user()
+        command = [
+            "runuser",
+            "-u",
+            user,
+            "--",
+            "env",
+            f"XDG_RUNTIME_DIR={env['XDG_RUNTIME_DIR']}",
+            f"DBUS_SESSION_BUS_ADDRESS={env['DBUS_SESSION_BUS_ADDRESS']}",
+            *args,
+        ]
+
+    return subprocess.run(
+        command,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        env=env,
+    )
+
+
+def _systemctl_user(*args: str) -> subprocess.CompletedProcess[str]:
+    return _run_as_deck(["systemctl", "--user", *args])
+
+
+def _download(url: str, dest: Path) -> None:
+    request = urllib.request.Request(url, headers={"User-Agent": "rabbit-digger-pro-decky"})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        dest.write_bytes(response.read())
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _download_verified(asset: dict[str, Any], dest: Path) -> None:
+    url = asset.get("url")
+    expected = asset.get("sha256")
+    if not url or not expected:
+        raise RuntimeError("asset is missing url or sha256")
+    _download(url, dest)
+    actual = _sha256(dest)
+    if actual.lower() != str(expected).lower():
+        raise RuntimeError(f"checksum mismatch for {url}")
+
+
+def _fetch_manifest() -> dict[str, Any]:
+    manifest_url = _load_update_config().get("manifest_url", DEFAULT_MANIFEST_URL)
+    with tempfile.TemporaryDirectory(prefix="rdp-manifest-") as temp:
+        path = Path(temp) / "manifest.json"
+        _download(manifest_url, path)
+        return json.loads(path.read_text())
+
+
+def _service_active() -> bool:
+    result = _systemctl_user("is-active", "--quiet", SERVICE_UNIT)
+    return result.returncode == 0
+
+
+def _install_helper(helper_path: Path) -> None:
+    token = _ensure_token()
+    result = _run_as_deck(
+        [
+            str(helper_path),
+            "service",
+            "install-user",
+            "--bind",
+            DEFAULT_BIND,
+            "--access-token",
+            token,
+            "--binary",
+            str(helper_path),
+        ],
+        timeout=120,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "helper install failed")
+
+
+def _install_plugin_zip(zip_path: Path) -> bool:
+    with tempfile.TemporaryDirectory(prefix="rdp-plugin-") as temp:
+        root = Path(temp)
+        with zipfile.ZipFile(zip_path) as archive:
+            archive.extractall(root)
+        candidates = [path for path in root.iterdir() if (path / "plugin.json").exists()]
+        source = candidates[0] if candidates else root
+        for child in source.iterdir():
+            dest = PLUGIN_DIR / child.name
+            if child.is_dir():
+                shutil.copytree(child, dest, dirs_exist_ok=True)
+            else:
+                shutil.copy2(child, dest)
+    return True
+
+
+def _status_from_manifest(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    plugin_version = _plugin_version()
+    latest = None
+    update_available = False
+    last_error = None
+
+    if manifest is not None:
+        latest = manifest.get("version")
+        update_available = bool(latest and latest != plugin_version)
+
+    return {
+        "installed": _helper_binary().exists(),
+        "active": _service_active(),
+        "helper_version": "installed" if _helper_binary().exists() else None,
+        "plugin_version": plugin_version,
+        "update_available": update_available,
+        "latest_version": latest,
+        "last_error": last_error,
+    }
+
+
+class Plugin:
+    async def _main(self):
+        print("Rabbit Digger Pro Decky backend initialized")
+
+    async def get_status(self):
+        return _status_from_manifest()
+
+    async def check_update(self):
+        try:
+            manifest = _fetch_manifest()
+            return _status_from_manifest(manifest)
+        except Exception as error:
+            status = _status_from_manifest()
+            status["last_error"] = str(error)
+            return status
+
+    async def apply_update(self):
+        try:
+            manifest = _fetch_manifest()
+            version = manifest.get("version")
+            needs_reload = False
+            with tempfile.TemporaryDirectory(prefix="rdp-update-") as temp:
+                temp_dir = Path(temp)
+                helper = manifest.get("helper")
+                if helper:
+                    helper_path = temp_dir / "rabbit-digger-pro"
+                    _download_verified(helper, helper_path)
+                    helper_path.chmod(0o755)
+                    _install_helper(helper_path)
+                    _systemctl_user("restart", SERVICE_UNIT)
+
+                decky_plugin = manifest.get("decky_plugin")
+                if decky_plugin:
+                    plugin_zip = temp_dir / "rabbit-digger-pro-decky.zip"
+                    _download_verified(decky_plugin, plugin_zip)
+                    needs_reload = _install_plugin_zip(plugin_zip)
+
+            return {
+                "ok": True,
+                "version": version,
+                "needs_reload": needs_reload,
+                "error": None,
+            }
+        except Exception as error:
+            return {
+                "ok": False,
+                "version": None,
+                "needs_reload": False,
+                "error": str(error),
+            }

--- a/packaging/decky/rabbit-digger-pro/package.json
+++ b/packaging/decky/rabbit-digger-pro/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "rabbit-digger-pro-decky",
+  "version": "0.1.0",
+  "description": "Decky Loader plugin for Rabbit Digger Pro",
+  "type": "module",
+  "scripts": {
+    "build": "rollup -c",
+    "watch": "rollup -c -w"
+  },
+  "keywords": ["decky", "steam-deck", "proxy", "rabbit-digger-pro"],
+  "author": "spacemeowx2",
+  "license": "MIT OR Apache-2.0",
+  "devDependencies": {
+    "@decky/rollup": "^1.0.2",
+    "@decky/ui": "^4.11.0",
+    "@rollup/rollup-linux-x64-musl": "^4.53.3",
+    "@types/react": "19.1.1",
+    "@types/react-dom": "19.1.1",
+    "@types/webpack": "^5.28.5",
+    "rollup": "^4.53.3",
+    "typescript": "^5.6.2"
+  },
+  "dependencies": {
+    "@decky/api": "^1.1.3",
+    "react-icons": "^5.3.0",
+    "tslib": "^2.7.0"
+  },
+  "pnpm": {
+    "peerDependencyRules": {
+      "ignoreMissing": ["react", "react-dom"]
+    }
+  }
+}

--- a/packaging/decky/rabbit-digger-pro/plugin.json
+++ b/packaging/decky/rabbit-digger-pro/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "Rabbit Digger Pro",
+  "author": "spacemeowx2",
+  "flags": [],
+  "api_version": 1,
+  "publish": {
+    "tags": ["network", "proxy", "steamdeck"],
+    "description": "Steam Deck Gaming Mode controls for Rabbit Digger Pro.",
+    "image": ""
+  }
+}

--- a/packaging/decky/rabbit-digger-pro/pnpm-lock.yaml
+++ b/packaging/decky/rabbit-digger-pro/pnpm-lock.yaml
@@ -1,0 +1,1881 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@decky/api':
+        specifier: ^1.1.3
+        version: 1.1.3
+      react-icons:
+        specifier: ^5.3.0
+        version: 5.6.0(react@19.2.6)
+      tslib:
+        specifier: ^2.7.0
+        version: 2.8.1
+    devDependencies:
+      '@decky/rollup':
+        specifier: ^1.0.2
+        version: 1.0.2
+      '@decky/ui':
+        specifier: ^4.11.0
+        version: 4.11.4
+      '@rollup/rollup-linux-x64-musl':
+        specifier: ^4.53.3
+        version: 4.60.4
+      '@types/react':
+        specifier: 19.1.1
+        version: 19.1.1
+      '@types/react-dom':
+        specifier: 19.1.1
+        version: 19.1.1(@types/react@19.1.1)
+      '@types/webpack':
+        specifier: ^5.28.5
+        version: 5.28.5
+      rollup:
+        specifier: ^4.53.3
+        version: 4.60.4
+      typescript:
+        specifier: ^5.6.2
+        version: 5.9.3
+
+packages:
+
+  '@decky/api@1.1.3':
+    resolution: {integrity: sha512-XsPCZxfxk5I1UtylIUN3qaWQI31siQbKfbLIskkI5innEatY1m4NQqBv/6hwPaO9mKMbdqYpnh5PSJDeMEOOBA==}
+
+  '@decky/rollup@1.0.2':
+    resolution: {integrity: sha512-ixuHH3msw156ACbgWZi4hgccdzDBIuqYGOVja8sLX4lHFgaWUKji1vomDi7Dk1CamgjmKt+Dqf75Pezv2FB6Bw==}
+
+  '@decky/ui@4.11.4':
+    resolution: {integrity: sha512-8rANkj5vkYTcT7VBBUzlBuowyBctU8gU5reWtsntmYdr7dGPLRqfgKDRqVH09HCd5plXyJKWDSpqiDsUHmKRJg==}
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@rollup/plugin-commonjs@26.0.3':
+    resolution: {integrity: sha512-2BJcolt43MY+y5Tz47djHkodCC3c1VKVrBDKpVqHKpQ9z9S158kCCqB8NF6/gzxLdNlYW9abB3Ibh+kOWLp8KQ==}
+    engines: {node: '>=16.0.0 || 14 >= 14.17'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-json@6.1.0':
+    resolution: {integrity: sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-node-resolve@15.3.1':
+    resolution: {integrity: sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-replace@5.0.7':
+    resolution: {integrity: sha512-PqxSfuorkHz/SPpyngLyg5GCEkOcee9M1bkxiVDr41Pd61mqP1PLOoDPbpl44SB2mQGKwV/In74gqQmGITOhEQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-typescript@11.1.6':
+    resolution: {integrity: sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.14.0||^3.0.0||^4.0.0
+      tslib: '*'
+      typescript: '>=3.7.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      tslib:
+        optional: true
+
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/eslint-scope@3.7.7':
+    resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
+
+  '@types/eslint@9.6.1':
+    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@25.9.0':
+    resolution: {integrity: sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==}
+
+  '@types/react-dom@19.1.1':
+    resolution: {integrity: sha512-jFf/woGTVTjUJsl2O7hcopJ1r0upqoq/vIOoCj0yLh3RIXxWcljlpuZ+vEBRXsymD1jhfeJrlyTy/S1UW+4y1w==}
+    peerDependencies:
+      '@types/react': ^19.0.0
+
+  '@types/react@19.1.1':
+    resolution: {integrity: sha512-ePapxDL7qrgqSF67s0h9m412d9DbXyC1n59O2st+9rjuuamWsZuD2w55rqY12CbzsZ7uVXb5Nw0gEp9Z8MMutQ==}
+
+  '@types/resolve@1.20.2':
+    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  '@types/webpack@5.28.5':
+    resolution: {integrity: sha512-wR87cgvxj3p6D0Crt1r5avwqffqPXUkNlnQ1mjU93G7gCuFjufZR4I6j8cz5g1F1tTYpfOOFvly+cmIQwL9wvw==}
+
+  '@webassemblyjs/ast@1.14.1':
+    resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2':
+    resolution: {integrity: sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==}
+
+  '@webassemblyjs/helper-api-error@1.13.2':
+    resolution: {integrity: sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==}
+
+  '@webassemblyjs/helper-buffer@1.14.1':
+    resolution: {integrity: sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    resolution: {integrity: sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==}
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2':
+    resolution: {integrity: sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    resolution: {integrity: sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==}
+
+  '@webassemblyjs/ieee754@1.13.2':
+    resolution: {integrity: sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==}
+
+  '@webassemblyjs/leb128@1.13.2':
+    resolution: {integrity: sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==}
+
+  '@webassemblyjs/utf8@1.13.2':
+    resolution: {integrity: sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    resolution: {integrity: sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==}
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    resolution: {integrity: sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==}
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    resolution: {integrity: sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==}
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    resolution: {integrity: sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==}
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
+
+  '@xtuc/ieee754@1.2.0':
+    resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
+
+  '@xtuc/long@4.2.2':
+    resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+
+  acorn-import-phases@1.0.4:
+    resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
+    engines: {node: '>=10.13.0'}
+    peerDependencies:
+      acorn: ^8.14.0
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  aggregate-error@3.1.0:
+    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
+    engines: {node: '>=8'}
+
+  ajv-formats@2.1.1:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-keywords@5.1.0:
+    resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
+    peerDependencies:
+      ajv: ^8.8.2
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  baseline-browser-mapping@2.10.31:
+    resolution: {integrity: sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  chrome-trace-event@1.0.4:
+    resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
+    engines: {node: '>=6.0'}
+
+  clean-stack@2.2.0:
+    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
+  del@6.1.1:
+    resolution: {integrity: sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==}
+    engines: {node: '>=10'}
+
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  electron-to-chromium@1.5.357:
+    resolution: {integrity: sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  enhanced-resolve@5.21.4:
+    resolution: {integrity: sha512-wE4fDO8OjJhrPFH69HUQStq5oKvGRTNXEyW+k5C/pUQLASSsTu7obd2V3GvCDgPcY9AWjhJ4jz9Kh7iRvrxhJg==}
+    engines: {node: '>=10.13.0'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  eslint-scope@5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  estree-walker@0.6.1:
+    resolution: {integrity: sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-module@1.0.0:
+    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-path-cwd@2.2.0:
+    resolution: {integrity: sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==}
+    engines: {node: '>=6'}
+
+  is-path-inside@3.0.3:
+    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
+    engines: {node: '>=8'}
+
+  is-reference@1.2.1:
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
+
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
+  is-what@5.5.0:
+    resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
+    engines: {node: '>=18'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jest-worker@27.5.1:
+    resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
+    engines: {node: '>= 10.13.0'}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  loader-runner@4.3.2:
+    resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
+    engines: {node: '>=6.11.5'}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  merge-anything@6.0.6:
+    resolution: {integrity: sha512-F3K1W45PvTjRZzbcYIhXntNr8cux00gUxR8IzNPPG+80gNlAHZGVBwFyN4x5yjw/7QkLPKDbRQBK4KrJKo69mw==}
+    engines: {node: '>=18'}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  node-releases@2.0.44:
+    resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  p-map@4.0.0:
+    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
+    engines: {node: '>=10'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  react-icons@5.6.0:
+    resolution: {integrity: sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==}
+    peerDependencies:
+      react: '*'
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rollup-plugin-delete@2.2.0:
+    resolution: {integrity: sha512-REKtDKWvjZlbrWpPvM9X/fadCs3E9I9ge27AK8G0e4bXwSLeABAAwtjiI1u3ihqZxk6mJeB2IVeSbH4DtOcw7A==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      rollup: '*'
+
+  rollup-plugin-external-globals@0.11.0:
+    resolution: {integrity: sha512-LR+sH2WkgWMPxsA5o5rT7uW7BeWXSeygLe60QQi9qoN/ufaCuHDaVOIbndIkqDPnZt/wZugJh5DCzkZFdSWlLQ==}
+    peerDependencies:
+      rollup: ^2.25.0 || ^3.3.0 || ^4.1.4
+
+  rollup-plugin-import-assets@1.1.1:
+    resolution: {integrity: sha512-u5zJwOjguTf2N+wETq2weNKGvNkuVc1UX/fPgg215p5xPvGOaI6/BTc024E9brvFjSQTfIYqgvwogQdipknu1g==}
+    peerDependencies:
+      rollup: '>=1.9.0'
+
+  rollup-pluginutils@2.8.2:
+    resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
+
+  rollup@4.60.4:
+    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  schema-utils@4.3.3:
+    resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
+    engines: {node: '>= 10.13.0'}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  terser-webpack-plugin@5.6.0:
+    resolution: {integrity: sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@minify-html/node': '*'
+      '@swc/core': '*'
+      '@swc/css': '*'
+      '@swc/html': '*'
+      clean-css: '*'
+      cssnano: '*'
+      csso: '*'
+      esbuild: '*'
+      html-minifier-terser: '*'
+      lightningcss: '*'
+      postcss: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@minify-html/node':
+        optional: true
+      '@swc/core':
+        optional: true
+      '@swc/css':
+        optional: true
+      '@swc/html':
+        optional: true
+      clean-css:
+        optional: true
+      cssnano:
+        optional: true
+      csso:
+        optional: true
+      esbuild:
+        optional: true
+      html-minifier-terser:
+        optional: true
+      lightningcss:
+        optional: true
+      postcss:
+        optional: true
+      uglify-js:
+        optional: true
+
+  terser@5.47.1:
+    resolution: {integrity: sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  url-join@4.0.1:
+    resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
+
+  watchpack@2.5.1:
+    resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
+    engines: {node: '>=10.13.0'}
+
+  webpack-sources@3.4.1:
+    resolution: {integrity: sha512-eACpxRN02yaawnt+uUNIF7Qje6A9zArxBbcAJjK1PK3S9Ycg5jIuJ8pW4q8EMnwNZCEGltcjkRx1QzOxOkKD8A==}
+    engines: {node: '>=10.13.0'}
+
+  webpack@5.106.2:
+    resolution: {integrity: sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+snapshots:
+
+  '@decky/api@1.1.3': {}
+
+  '@decky/rollup@1.0.2':
+    dependencies:
+      '@rollup/plugin-commonjs': 26.0.3(rollup@4.60.4)
+      '@rollup/plugin-json': 6.1.0(rollup@4.60.4)
+      '@rollup/plugin-node-resolve': 15.3.1(rollup@4.60.4)
+      '@rollup/plugin-replace': 5.0.7(rollup@4.60.4)
+      '@rollup/plugin-typescript': 11.1.6(rollup@4.60.4)(tslib@2.8.1)(typescript@5.9.3)
+      merge-anything: 6.0.6
+      rollup: 4.60.4
+      rollup-plugin-delete: 2.2.0(rollup@4.60.4)
+      rollup-plugin-external-globals: 0.11.0(rollup@4.60.4)
+      rollup-plugin-import-assets: 1.1.1(rollup@4.60.4)
+      tslib: 2.8.1
+      typescript: 5.9.3
+
+  '@decky/ui@4.11.4': {}
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/source-map@0.3.11':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@rollup/plugin-commonjs@26.0.3(rollup@4.60.4)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      glob: 10.5.0
+      is-reference: 1.2.1
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.60.4
+
+  '@rollup/plugin-json@6.1.0(rollup@4.60.4)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
+    optionalDependencies:
+      rollup: 4.60.4
+
+  '@rollup/plugin-node-resolve@15.3.1(rollup@4.60.4)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
+      '@types/resolve': 1.20.2
+      deepmerge: 4.3.1
+      is-module: 1.0.0
+      resolve: 1.22.12
+    optionalDependencies:
+      rollup: 4.60.4
+
+  '@rollup/plugin-replace@5.0.7(rollup@4.60.4)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.60.4
+
+  '@rollup/plugin-typescript@11.1.6(rollup@4.60.4)(tslib@2.8.1)(typescript@5.9.3)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
+      resolve: 1.22.12
+      typescript: 5.9.3
+    optionalDependencies:
+      rollup: 4.60.4
+      tslib: 2.8.1
+
+  '@rollup/pluginutils@5.3.0(rollup@4.60.4)':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
+    optionalDependencies:
+      rollup: 4.60.4
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.4': {}
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    optional: true
+
+  '@types/eslint-scope@3.7.7':
+    dependencies:
+      '@types/eslint': 9.6.1
+      '@types/estree': 1.0.9
+
+  '@types/eslint@9.6.1':
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+
+  '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/node@25.9.0':
+    dependencies:
+      undici-types: 7.24.6
+
+  '@types/react-dom@19.1.1(@types/react@19.1.1)':
+    dependencies:
+      '@types/react': 19.1.1
+
+  '@types/react@19.1.1':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/resolve@1.20.2': {}
+
+  '@types/webpack@5.28.5':
+    dependencies:
+      '@types/node': 25.9.0
+      tapable: 2.3.3
+      webpack: 5.106.2
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+      - webpack-cli
+
+  '@webassemblyjs/ast@1.14.1':
+    dependencies:
+      '@webassemblyjs/helper-numbers': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2': {}
+
+  '@webassemblyjs/helper-api-error@1.13.2': {}
+
+  '@webassemblyjs/helper-buffer@1.14.1': {}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    dependencies:
+      '@webassemblyjs/floating-point-hex-parser': 1.13.2
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2': {}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/wasm-gen': 1.14.1
+
+  '@webassemblyjs/ieee754@1.13.2':
+    dependencies:
+      '@xtuc/ieee754': 1.2.0
+
+  '@webassemblyjs/leb128@1.13.2':
+    dependencies:
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/utf8@1.13.2': {}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/helper-wasm-section': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-opt': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      '@webassemblyjs/wast-printer': 1.14.1
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@xtuc/long': 4.2.2
+
+  '@xtuc/ieee754@1.2.0': {}
+
+  '@xtuc/long@4.2.2': {}
+
+  acorn-import-phases@1.0.4(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  aggregate-error@3.1.0:
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
+
+  ajv-formats@2.1.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv-keywords@5.1.0(ajv@8.20.0):
+    dependencies:
+      ajv: 8.20.0
+      fast-deep-equal: 3.1.3
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
+  array-union@2.1.0: {}
+
+  balanced-match@1.0.2: {}
+
+  baseline-browser-mapping@2.10.31: {}
+
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.31
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.357
+      node-releases: 2.0.44
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-from@1.1.2: {}
+
+  caniuse-lite@1.0.30001793: {}
+
+  chrome-trace-event@1.0.4: {}
+
+  clean-stack@2.2.0: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@2.20.3: {}
+
+  commondir@1.0.1: {}
+
+  concat-map@0.0.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  csstype@3.2.3: {}
+
+  deepmerge@4.3.1: {}
+
+  del@6.1.1:
+    dependencies:
+      globby: 11.1.0
+      graceful-fs: 4.2.11
+      is-glob: 4.0.3
+      is-path-cwd: 2.2.0
+      is-path-inside: 3.0.3
+      p-map: 4.0.0
+      rimraf: 3.0.2
+      slash: 3.0.0
+
+  dir-glob@3.0.1:
+    dependencies:
+      path-type: 4.0.0
+
+  eastasianwidth@0.2.0: {}
+
+  electron-to-chromium@1.5.357: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  enhanced-resolve@5.21.4:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@2.1.0: {}
+
+  escalade@3.2.0: {}
+
+  eslint-scope@5.1.1:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@4.3.0: {}
+
+  estraverse@5.3.0: {}
+
+  estree-walker@0.6.1: {}
+
+  estree-walker@2.0.2: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  events@3.3.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-uri@3.1.2: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  fs.realpath@1.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-to-regexp@0.4.1: {}
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  globby@11.1.0:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.3
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 3.0.0
+
+  graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  ignore@5.3.2: {}
+
+  indent-string@4.0.0: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.3
+
+  is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-module@1.0.0: {}
+
+  is-number@7.0.0: {}
+
+  is-path-cwd@2.2.0: {}
+
+  is-path-inside@3.0.3: {}
+
+  is-reference@1.2.1:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  is-what@5.5.0: {}
+
+  isexe@2.0.0: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  jest-worker@27.5.1:
+    dependencies:
+      '@types/node': 25.9.0
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
+  json-schema-traverse@1.0.0: {}
+
+  loader-runner@4.3.2: {}
+
+  lru-cache@10.4.3: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  merge-anything@6.0.6:
+    dependencies:
+      is-what: 5.5.0
+
+  merge-stream@2.0.0: {}
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  mime-db@1.54.0: {}
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
+  minipass@7.1.3: {}
+
+  neo-async@2.6.2: {}
+
+  node-releases@2.0.44: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  p-map@4.0.0:
+    dependencies:
+      aggregate-error: 3.1.0
+
+  package-json-from-dist@1.0.1: {}
+
+  path-is-absolute@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  path-type@4.0.0: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
+
+  queue-microtask@1.2.3: {}
+
+  react-icons@5.6.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
+  react@19.2.6: {}
+
+  require-from-string@2.0.2: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  reusify@1.1.0: {}
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
+
+  rollup-plugin-delete@2.2.0(rollup@4.60.4):
+    dependencies:
+      del: 6.1.1
+      rollup: 4.60.4
+
+  rollup-plugin-external-globals@0.11.0(rollup@4.60.4):
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.4)
+      estree-walker: 3.0.3
+      is-reference: 3.0.3
+      magic-string: 0.30.21
+      rollup: 4.60.4
+
+  rollup-plugin-import-assets@1.1.1(rollup@4.60.4):
+    dependencies:
+      rollup: 4.60.4
+      rollup-pluginutils: 2.8.2
+      url-join: 4.0.1
+
+  rollup-pluginutils@2.8.2:
+    dependencies:
+      estree-walker: 0.6.1
+
+  rollup@4.60.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.4
+      '@rollup/rollup-android-arm64': 4.60.4
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-darwin-x64': 4.60.4
+      '@rollup/rollup-freebsd-arm64': 4.60.4
+      '@rollup/rollup-freebsd-x64': 4.60.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-loong64-gnu': 4.60.4
+      '@rollup/rollup-linux-loong64-musl': 4.60.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
+      '@rollup/rollup-linux-ppc64-musl': 4.60.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
+      '@rollup/rollup-linux-riscv64-musl': 4.60.4
+      '@rollup/rollup-linux-s390x-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-openbsd-x64': 4.60.4
+      '@rollup/rollup-openharmony-arm64': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-ia32-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
+      fsevents: 2.3.3
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  schema-utils@4.3.3:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      ajv-keywords: 5.1.0(ajv@8.20.0)
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  slash@3.0.0: {}
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  tapable@2.3.3: {}
+
+  terser-webpack-plugin@5.6.0(webpack@5.106.2):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.47.1
+      webpack: 5.106.2
+
+  terser@5.47.1:
+    dependencies:
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.16.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  tslib@2.8.1: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@7.24.6: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  url-join@4.0.1: {}
+
+  watchpack@2.5.1:
+    dependencies:
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+
+  webpack-sources@3.4.1: {}
+
+  webpack@5.106.2:
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.2
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.21.4
+      es-module-lexer: 2.1.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.0(webpack@5.106.2)
+      watchpack: 2.5.1
+      webpack-sources: 3.4.1
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
+  wrappy@1.0.2: {}

--- a/packaging/decky/rabbit-digger-pro/rollup.config.js
+++ b/packaging/decky/rabbit-digger-pro/rollup.config.js
@@ -1,0 +1,3 @@
+import deckyPlugin from "@decky/rollup";
+
+export default deckyPlugin({});

--- a/packaging/decky/rabbit-digger-pro/src/index.tsx
+++ b/packaging/decky/rabbit-digger-pro/src/index.tsx
@@ -1,0 +1,153 @@
+import {
+  ButtonItem,
+  PanelSection,
+  PanelSectionRow,
+  Spinner,
+  staticClasses,
+} from "@decky/ui";
+import { callable, definePlugin, toaster } from "@decky/api";
+import { useEffect, useState } from "react";
+import { FaNetworkWired } from "react-icons/fa";
+
+type HelperStatus = {
+  installed: boolean;
+  active: boolean;
+  helper_version: string | null;
+  plugin_version: string;
+  update_available: boolean;
+  latest_version: string | null;
+  last_error: string | null;
+};
+
+type UpdateResult = {
+  ok: boolean;
+  version: string | null;
+  needs_reload: boolean;
+  error: string | null;
+};
+
+const getStatus = callable<[], HelperStatus>("get_status");
+const checkUpdate = callable<[], HelperStatus>("check_update");
+const applyUpdate = callable<[], UpdateResult>("apply_update");
+
+function StateText({ status }: { status: HelperStatus | null }) {
+  if (!status) {
+    return <div>Loading...</div>;
+  }
+
+  const rows = [
+    ["Helper", status.installed ? "Installed" : "Missing"],
+    ["Service", status.active ? "Running" : "Stopped"],
+    ["Plugin", status.plugin_version],
+    ["Helper version", status.helper_version ?? "Unknown"],
+    ["Latest", status.latest_version ?? "Unknown"],
+  ];
+
+  return (
+    <div style={{ display: "grid", gap: "6px", fontSize: "13px" }}>
+      {rows.map(([label, value]) => (
+        <div
+          key={label}
+          style={{ display: "flex", justifyContent: "space-between", gap: "12px" }}
+        >
+          <span style={{ color: "#8f98a0" }}>{label}</span>
+          <span>{value}</span>
+        </div>
+      ))}
+      {status.last_error ? (
+        <div style={{ color: "#ff8a8a", marginTop: "4px" }}>{status.last_error}</div>
+      ) : null}
+    </div>
+  );
+}
+
+function Content() {
+  const [status, setStatus] = useState<HelperStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = async () => {
+    setStatus(await getStatus());
+  };
+
+  const onCheckUpdate = async () => {
+    setBusy(true);
+    try {
+      const next = await checkUpdate();
+      setStatus(next);
+      toaster.toast({
+        title: "Rabbit Digger Pro",
+        body: next.update_available ? "Update available" : "Already up to date",
+      });
+    } catch (error) {
+      toaster.toast({ title: "Update check failed", body: String(error) });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onApplyUpdate = async () => {
+    setBusy(true);
+    try {
+      const result = await applyUpdate();
+      await refresh();
+      if (result.ok) {
+        toaster.toast({
+          title: "Rabbit Digger Pro updated",
+          body: result.needs_reload
+            ? "Reload Decky or restart Gaming Mode to finish plugin update"
+            : `Installed ${result.version ?? "latest version"}`,
+        });
+      } else {
+        toaster.toast({
+          title: "Rabbit Digger Pro update failed",
+          body: result.error ?? "Unknown error",
+        });
+      }
+    } catch (error) {
+      toaster.toast({ title: "Rabbit Digger Pro update failed", body: String(error) });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  return (
+    <PanelSection title="Status">
+      <PanelSectionRow>
+        <StateText status={status} />
+      </PanelSectionRow>
+      {busy ? (
+        <PanelSectionRow>
+          <Spinner />
+        </PanelSectionRow>
+      ) : null}
+      <PanelSectionRow>
+        <ButtonItem layout="below" onClick={refresh}>
+          Refresh
+        </ButtonItem>
+      </PanelSectionRow>
+      <PanelSectionRow>
+        <ButtonItem layout="below" onClick={onCheckUpdate}>
+          Check Update
+        </ButtonItem>
+      </PanelSectionRow>
+      <PanelSectionRow>
+        <ButtonItem layout="below" onClick={onApplyUpdate}>
+          Update
+        </ButtonItem>
+      </PanelSectionRow>
+    </PanelSection>
+  );
+}
+
+export default definePlugin(() => {
+  return {
+    name: "Rabbit Digger Pro",
+    titleView: <div className={staticClasses.Title}>Rabbit Digger Pro</div>,
+    content: <Content />,
+    icon: <FaNetworkWired />,
+  };
+});

--- a/packaging/decky/rabbit-digger-pro/src/types.d.ts
+++ b/packaging/decky/rabbit-digger-pro/src/types.d.ts
@@ -1,0 +1,4 @@
+declare module "*.svg" {
+  const content: string;
+  export default content;
+}

--- a/packaging/decky/rabbit-digger-pro/tsconfig.json
+++ b/packaging/decky/rabbit-digger-pro/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "target": "ES2020"
+  },
+  "include": ["src"]
+}

--- a/scripts/build-steamdeck-release.sh
+++ b/scripts/build-steamdeck-release.sh
@@ -53,8 +53,17 @@ rm -rf "$PACKAGE_ROOT"
 mkdir -p "$PACKAGE_ROOT/rabbit-digger-pro"
 cp -R "$PLUGIN_DIR/dist" "$PACKAGE_ROOT/rabbit-digger-pro/dist"
 cp "$PLUGIN_DIR/main.py" "$PACKAGE_ROOT/rabbit-digger-pro/main.py"
-cp "$PLUGIN_DIR/package.json" "$PACKAGE_ROOT/rabbit-digger-pro/package.json"
 cp "$PLUGIN_DIR/plugin.json" "$PACKAGE_ROOT/rabbit-digger-pro/plugin.json"
+python3 - "$PLUGIN_DIR/package.json" "$PACKAGE_ROOT/rabbit-digger-pro/package.json" "$VERSION" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+source, dest, version = sys.argv[1:]
+package = json.loads(Path(source).read_text(encoding="utf-8"))
+package["version"] = version
+Path(dest).write_text(json.dumps(package, indent=2) + "\n", encoding="utf-8")
+PY
 
 (
   cd "$PACKAGE_ROOT"

--- a/scripts/build-steamdeck-release.sh
+++ b/scripts/build-steamdeck-release.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="${RDP_VERSION:-$(grep -m1 '^version =' "$ROOT/Cargo.toml" | sed -E 's/version = "([^"]+)"/\1/')}"
+CHANNEL="${RDP_CHANNEL:-dev}"
+OUT_DIR="${RDP_OUT_DIR:-$ROOT/dist/steamdeck}"
+RELEASE_BASE_URL="${RDP_RELEASE_BASE_URL:-https://github.com/spacemeowx2/rabbit-digger-pro/releases/download/v$VERSION}"
+PLUGIN_DIR="$ROOT/packaging/decky/rabbit-digger-pro"
+HELPER_NAME="rabbit-digger-pro-x86_64-unknown-linux-gnu"
+PLUGIN_ZIP="rabbit-digger-pro-decky.zip"
+MANIFEST_NAME="steamdeck-update-manifest.json"
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+need_cmd cargo
+need_cmd pnpm
+need_cmd python3
+need_cmd zip
+
+if [ "$(uname -s)" != "Linux" ] && [ "${RDP_ALLOW_NON_LINUX:-0}" != "1" ]; then
+  echo "Steam Deck release assets must be built on Linux. Set RDP_ALLOW_NON_LINUX=1 for local smoke builds." >&2
+  exit 1
+fi
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+cargo build --release --features webui_embed
+cp "$ROOT/target/release/rabbit-digger-pro" "$OUT_DIR/$HELPER_NAME"
+
+(
+  cd "$PLUGIN_DIR"
+  pnpm install --frozen-lockfile=false
+  pnpm run build
+)
+
+PACKAGE_ROOT="$OUT_DIR/plugin-package"
+rm -rf "$PACKAGE_ROOT"
+mkdir -p "$PACKAGE_ROOT/rabbit-digger-pro"
+cp -R "$PLUGIN_DIR/dist" "$PACKAGE_ROOT/rabbit-digger-pro/dist"
+cp "$PLUGIN_DIR/main.py" "$PACKAGE_ROOT/rabbit-digger-pro/main.py"
+cp "$PLUGIN_DIR/package.json" "$PACKAGE_ROOT/rabbit-digger-pro/package.json"
+cp "$PLUGIN_DIR/plugin.json" "$PACKAGE_ROOT/rabbit-digger-pro/plugin.json"
+
+(
+  cd "$PACKAGE_ROOT"
+  zip -qr "$OUT_DIR/$PLUGIN_ZIP" rabbit-digger-pro
+)
+rm -rf "$PACKAGE_ROOT"
+
+HELPER_SHA="$(sha256_file "$OUT_DIR/$HELPER_NAME")"
+PLUGIN_SHA="$(sha256_file "$OUT_DIR/$PLUGIN_ZIP")"
+
+python3 - "$OUT_DIR/$MANIFEST_NAME" "$VERSION" "$CHANNEL" "$RELEASE_BASE_URL" "$HELPER_NAME" "$HELPER_SHA" "$PLUGIN_ZIP" "$PLUGIN_SHA" <<'PY'
+import datetime
+import json
+import sys
+from pathlib import Path
+
+path, version, channel, base, helper_name, helper_sha, plugin_zip, plugin_sha = sys.argv[1:]
+manifest = {
+    "version": version,
+    "channel": channel,
+    "published_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    "helper": {
+        "url": f"{base}/{helper_name}",
+        "sha256": helper_sha,
+    },
+    "decky_plugin": {
+        "url": f"{base}/{plugin_zip}",
+        "sha256": plugin_sha,
+    },
+}
+Path(path).write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+PY
+
+echo "Steam Deck release assets written to $OUT_DIR"
+ls -lh "$OUT_DIR"

--- a/scripts/install-steamdeck.sh
+++ b/scripts/install-steamdeck.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_MANIFEST_URL="https://github.com/spacemeowx2/rabbit-digger-pro/releases/latest/download/steamdeck-update-manifest.json"
+DEFAULT_DECKY_INSTALLER_URL="https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_release.sh"
+MANIFEST_URL="${RDP_MANIFEST_URL:-$DEFAULT_MANIFEST_URL}"
+DECKY_INSTALLER_URL="${RDP_DECKY_INSTALLER_URL:-$DEFAULT_DECKY_INSTALLER_URL}"
+SKIP_DECKY_INSTALL="${RDP_SKIP_DECKY_INSTALL:-0}"
+REQUIRE_DECKY="${RDP_REQUIRE_DECKY:-0}"
+BIND="${RDP_BIND:-127.0.0.1:9091}"
+COMMAND="${1:-install}"
+
+DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+RDP_DATA_DIR="$DATA_HOME/rabbit_digger_pro"
+RDP_CONFIG_DIR="$CONFIG_HOME/rabbit_digger_pro"
+TOKEN_PATH="$RDP_DATA_DIR/decky-token"
+UPDATE_CONFIG_PATH="$RDP_CONFIG_DIR/decky-update.json"
+PLUGIN_DIR="$HOME/homebrew/plugins/rabbit-digger-pro"
+HELPER_DIR="$RDP_DATA_DIR/helper"
+HELPER_PATH="$HELPER_DIR/rabbit-digger-pro"
+USER_UNIT_PATH="$CONFIG_HOME/systemd/user/rabbit-digger-pro.service"
+TMP_DIR=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/install-steamdeck.sh [install|update]
+  scripts/install-steamdeck.sh uninstall
+
+Environment:
+  RDP_MANIFEST_URL         Override the update manifest URL.
+  RDP_BIND                 Override helper bind address. Default: 127.0.0.1:9091.
+  RDP_SKIP_DECKY_INSTALL   Set to 1 to skip the Decky Loader auto-install attempt.
+  RDP_REQUIRE_DECKY        Set to 1 to fail if Decky Loader is missing.
+EOF
+}
+
+cleanup_tmp() {
+  if [ -n "${TMP_DIR:-}" ]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+
+trap cleanup_tmp EXIT
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+json_get() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+path, dotted = sys.argv[1], sys.argv[2]
+value = json.load(open(path, "r", encoding="utf-8"))
+for part in dotted.split("."):
+    value = value[part]
+print(value)
+PY
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+download_verified() {
+  local url="$1"
+  local expected="$2"
+  local dest="$3"
+
+  curl -fL "$url" -o "$dest"
+  local actual
+  actual="$(sha256_file "$dest")"
+  if [ "$actual" != "$expected" ]; then
+    echo "Checksum mismatch for $url" >&2
+    echo "expected: $expected" >&2
+    echo "actual:   $actual" >&2
+    exit 1
+  fi
+}
+
+decky_installed() {
+  if systemctl is-active --quiet plugin_loader 2>/dev/null; then
+    return 0
+  fi
+  if systemctl is-enabled --quiet plugin_loader 2>/dev/null; then
+    return 0
+  fi
+  if [ -x "$HOME/homebrew/services/PluginLoader" ]; then
+    return 0
+  fi
+  return 1
+}
+
+install_decky_loader() {
+  if [ "$SKIP_DECKY_INSTALL" = "1" ]; then
+    echo "Decky Loader auto-install skipped."
+    return 1
+  fi
+
+  if ! curl -fsI --connect-timeout 8 --max-time 20 https://github.com >/dev/null; then
+    echo "Decky Loader was not detected, and GitHub is not reachable from this Steam Deck."
+    echo "Continuing without Decky Loader; the Rabbit Digger Pro plugin files will still be staged."
+    return 1
+  fi
+
+  echo "Decky Loader was not detected. Installing Decky Loader from the official installer..."
+  local installer="$TMP_DIR/decky-install-release.sh"
+  if ! curl -fL --connect-timeout 8 --max-time 60 "$DECKY_INSTALLER_URL" -o "$installer"; then
+    echo "Failed to download the Decky Loader installer."
+    return 1
+  fi
+  if ! sh "$installer"; then
+    echo "Decky Loader installer failed."
+    return 1
+  fi
+
+  if ! decky_installed; then
+    echo "Decky Loader installation did not complete or could not be detected." >&2
+    return 1
+  fi
+
+  return 0
+}
+
+restart_decky_loader_if_running() {
+  if systemctl is-active --quiet plugin_loader 2>/dev/null; then
+    systemctl restart plugin_loader 2>/dev/null || true
+  fi
+}
+
+fallback_uninstall_user_service() {
+  systemctl --user stop rabbit-digger-pro.service 2>/dev/null || true
+  systemctl --user disable rabbit-digger-pro.service 2>/dev/null || true
+  rm -f "$USER_UNIT_PATH"
+  systemctl --user daemon-reload 2>/dev/null || true
+  rm -f "$HELPER_PATH"
+}
+
+install_or_update() {
+  need_cmd curl
+  need_cmd python3
+  need_cmd systemctl
+  need_cmd unzip
+
+  mkdir -p "$RDP_DATA_DIR" "$RDP_CONFIG_DIR"
+
+  if [ ! -f "$TOKEN_PATH" ]; then
+    python3 - "$TOKEN_PATH" <<'PY'
+import secrets
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+path.write_text(secrets.token_urlsafe(32), encoding="utf-8")
+path.chmod(0o600)
+PY
+  fi
+
+  TOKEN="$(cat "$TOKEN_PATH")"
+  TMP_DIR="$(mktemp -d)"
+  DECKY_READY=0
+
+  if decky_installed; then
+    DECKY_READY=1
+  elif install_decky_loader; then
+    DECKY_READY=1
+  elif [ "$REQUIRE_DECKY" = "1" ]; then
+    echo "Decky Loader is required but is not installed." >&2
+    exit 1
+  fi
+
+  MANIFEST_PATH="$TMP_DIR/manifest.json"
+  curl -fL "$MANIFEST_URL" -o "$MANIFEST_PATH"
+
+  HELPER_URL="$(json_get "$MANIFEST_PATH" helper.url)"
+  HELPER_SHA="$(json_get "$MANIFEST_PATH" helper.sha256)"
+  PLUGIN_URL="$(json_get "$MANIFEST_PATH" decky_plugin.url)"
+  PLUGIN_SHA="$(json_get "$MANIFEST_PATH" decky_plugin.sha256)"
+
+  HELPER_TMP="$TMP_DIR/rabbit-digger-pro"
+  PLUGIN_TMP="$TMP_DIR/rabbit-digger-pro-decky.zip"
+
+  download_verified "$HELPER_URL" "$HELPER_SHA" "$HELPER_TMP"
+  chmod +x "$HELPER_TMP"
+
+  "$HELPER_TMP" service install-user \
+    --bind "$BIND" \
+    --access-token "$TOKEN" \
+    --binary "$HELPER_TMP"
+
+  download_verified "$PLUGIN_URL" "$PLUGIN_SHA" "$PLUGIN_TMP"
+  rm -rf "$TMP_DIR/plugin"
+  mkdir -p "$TMP_DIR/plugin"
+  unzip -q "$PLUGIN_TMP" -d "$TMP_DIR/plugin"
+
+  rm -rf "$PLUGIN_DIR"
+  mkdir -p "$(dirname "$PLUGIN_DIR")"
+  PLUGIN_ROOT="$(find "$TMP_DIR/plugin" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+  if [ -z "$PLUGIN_ROOT" ]; then
+    echo "Plugin zip did not contain a plugin directory" >&2
+    exit 1
+  fi
+  cp -R "$PLUGIN_ROOT" "$PLUGIN_DIR"
+
+  restart_decky_loader_if_running
+
+  python3 - "$UPDATE_CONFIG_PATH" "$MANIFEST_URL" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(json.dumps({"manifest_url": sys.argv[2]}, indent=2), encoding="utf-8")
+PY
+
+  echo "Rabbit Digger Pro installed."
+  if [ "$DECKY_READY" = "1" ]; then
+    echo "Return to Gaming Mode and open Decky Loader."
+  else
+    echo "Decky Loader is not installed yet, so the Gaming Mode menu will not appear."
+    echo "The helper and plugin files are staged; install Decky Loader later and restart it."
+  fi
+}
+
+uninstall_rdp() {
+  need_cmd systemctl
+
+  echo "Uninstalling Rabbit Digger Pro..."
+
+  if [ -x "$HELPER_PATH" ]; then
+    if ! "$HELPER_PATH" service uninstall-user; then
+      echo "Helper uninstall failed; continuing with fallback cleanup." >&2
+      fallback_uninstall_user_service
+    fi
+  else
+    fallback_uninstall_user_service
+  fi
+
+  rm -rf "$PLUGIN_DIR"
+  rm -f "$TOKEN_PATH" "$UPDATE_CONFIG_PATH"
+  rmdir "$HELPER_DIR" "$RDP_DATA_DIR" "$RDP_CONFIG_DIR" 2>/dev/null || true
+  restart_decky_loader_if_running
+
+  echo "Rabbit Digger Pro removed."
+  echo "Decky Loader was left installed because other plugins may depend on it."
+}
+
+case "$COMMAND" in
+  install | update)
+    shift || true
+    if [ "$#" -ne 0 ]; then
+      usage >&2
+      exit 1
+    fi
+    install_or_update
+    ;;
+  uninstall | remove | clean | --uninstall)
+    shift || true
+    if [ "$#" -ne 0 ]; then
+      usage >&2
+      exit 1
+    fi
+    uninstall_rdp
+    ;;
+  -h | --help | help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/src/service/linux.rs
+++ b/src/service/linux.rs
@@ -7,9 +7,51 @@ use super::ServiceAction;
 
 const SERVICE_NAME: &str = "rabbit-digger-pro";
 const INSTALL_DIR: &str = "/usr/local/bin";
+const USER_UNIT_NAME: &str = "rabbit-digger-pro.service";
 
 fn installed_binary() -> PathBuf {
     PathBuf::from(INSTALL_DIR).join(SERVICE_NAME)
+}
+
+fn user_helper_binary() -> PathBuf {
+    let base = std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .or_else(dirs::data_local_dir)
+        .unwrap_or_else(|| {
+            let home = std::env::var_os("HOME")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("."));
+            home.join(".local/share")
+        });
+    base.join("rabbit_digger_pro")
+        .join("helper")
+        .join(SERVICE_NAME)
+}
+
+fn user_unit_path() -> PathBuf {
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(dirs::config_dir)
+        .unwrap_or_else(|| {
+            let home = std::env::var_os("HOME")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("."));
+            home.join(".config")
+        });
+    base.join("systemd").join("user").join(USER_UNIT_NAME)
+}
+
+fn user_env_path() -> PathBuf {
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(dirs::config_dir)
+        .unwrap_or_else(|| {
+            let home = std::env::var_os("HOME")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("."));
+            home.join(".config")
+        });
+    base.join("rabbit_digger_pro").join("helper.env")
 }
 
 // ---------------------------------------------------------------------------
@@ -42,10 +84,19 @@ pub async fn handle_service_action(action: ServiceAction) -> Result<()> {
         ServiceAction::Install { bind, access_token } => {
             install(&bind, access_token.as_deref()).await
         }
+        ServiceAction::InstallUser {
+            bind,
+            access_token,
+            binary,
+        } => install_user(&bind, access_token.as_deref(), binary.as_deref()).await,
         ServiceAction::Uninstall => uninstall().await,
+        ServiceAction::UninstallUser => uninstall_user().await,
         ServiceAction::Start => start().await,
+        ServiceAction::StartUser => start_user().await,
         ServiceAction::Stop => stop().await,
+        ServiceAction::StopUser => stop_user().await,
         ServiceAction::Status => status().await,
+        ServiceAction::StatusUser => status_user().await,
         ServiceAction::Run { .. } => unreachable!("Run is handled by daemon module"),
     }
 }
@@ -112,6 +163,93 @@ WantedBy=multi-user.target
     run("systemctl", &["start", SERVICE_NAME])?;
 
     println!("  Unit:   {unit_path}");
+    Ok(())
+}
+
+fn render_user_systemd_unit(binary: &Path, bind: &str, env_path: Option<&Path>) -> Result<String> {
+    let binary = binary.to_str().context("Invalid binary path")?;
+    let exec_start = format!("{binary} service run --bind {bind}");
+    let environment_file = match env_path {
+        Some(path) => {
+            let path = path.to_str().context("Invalid environment file path")?;
+            format!("EnvironmentFile={path}\n")
+        }
+        None => String::new(),
+    };
+
+    Ok(format!(
+        r#"[Unit]
+Description=Rabbit Digger Pro User Helper
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+{environment_file}ExecStart={exec_start}
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=default.target
+"#
+    ))
+}
+
+async fn install_user(bind: &str, access_token: Option<&str>, binary: Option<&Path>) -> Result<()> {
+    let source = match binary {
+        Some(path) => path.to_path_buf(),
+        None => std::env::current_exe().context("Cannot determine binary path")?,
+    };
+    let dest = user_helper_binary();
+    let dest_dir = dest
+        .parent()
+        .context("Cannot determine user helper directory")?;
+    std::fs::create_dir_all(dest_dir)?;
+
+    let tmp_dest = dest.with_extension("tmp");
+    std::fs::copy(&source, &tmp_dest).with_context(|| {
+        format!(
+            "Failed to copy binary from {} to {}",
+            source.display(),
+            tmp_dest.display()
+        )
+    })?;
+    let _ = Command::new("chmod")
+        .args(["755", tmp_dest.to_str().unwrap()])
+        .output();
+    std::fs::rename(&tmp_dest, &dest)
+        .with_context(|| format!("Failed to install binary to {}", dest.display()))?;
+
+    let unit_path = user_unit_path();
+    let unit_dir = unit_path
+        .parent()
+        .context("Cannot determine systemd user unit directory")?;
+    std::fs::create_dir_all(unit_dir)?;
+    let env_path = if let Some(token) = access_token {
+        let env_path = user_env_path();
+        let env_dir = env_path
+            .parent()
+            .context("Cannot determine service environment directory")?;
+        std::fs::create_dir_all(env_dir)?;
+        std::fs::write(&env_path, format!("RD_ACCESS_TOKEN={token}\n"))
+            .context("Failed to write service environment file")?;
+        let _ = Command::new("chmod")
+            .args(["600", env_path.to_str().unwrap()])
+            .output();
+        Some(env_path)
+    } else {
+        None
+    };
+    let unit = render_user_systemd_unit(&dest, bind, env_path.as_deref())?;
+    std::fs::write(&unit_path, unit).context("Failed to write systemd user unit")?;
+
+    run("systemctl", &["--user", "daemon-reload"])?;
+    run("systemctl", &["--user", "enable", "--now", USER_UNIT_NAME])?;
+
+    println!("User service installed.");
+    println!("  Binary: {}", dest.display());
+    println!("  Unit:   {}", unit_path.display());
+    println!("  WebUI:  http://{}", bind);
     Ok(())
 }
 
@@ -188,6 +326,29 @@ async fn uninstall() -> Result<()> {
     Ok(())
 }
 
+async fn uninstall_user() -> Result<()> {
+    let _ = run("systemctl", &["--user", "stop", USER_UNIT_NAME]);
+    let _ = run("systemctl", &["--user", "disable", USER_UNIT_NAME]);
+
+    let unit_path = user_unit_path();
+    if unit_path.exists() {
+        std::fs::remove_file(&unit_path)?;
+    }
+    let env_path = user_env_path();
+    if env_path.exists() {
+        std::fs::remove_file(&env_path)?;
+    }
+    let _ = run("systemctl", &["--user", "daemon-reload"]);
+
+    let dest = user_helper_binary();
+    if dest.exists() {
+        std::fs::remove_file(&dest)?;
+    }
+
+    println!("User service uninstalled.");
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Start / Stop / Status
 // ---------------------------------------------------------------------------
@@ -201,12 +362,24 @@ async fn start() -> Result<()> {
     Ok(())
 }
 
+async fn start_user() -> Result<()> {
+    run("systemctl", &["--user", "start", USER_UNIT_NAME])?;
+    println!("User service started.");
+    Ok(())
+}
+
 async fn stop() -> Result<()> {
     match detect_init()? {
         InitSystem::Systemd => run("systemctl", &["stop", SERVICE_NAME])?,
         InitSystem::Procd => run(&format!("/etc/init.d/{SERVICE_NAME}"), &["stop"])?,
     }
     println!("Service stopped.");
+    Ok(())
+}
+
+async fn stop_user() -> Result<()> {
+    run("systemctl", &["--user", "stop", USER_UNIT_NAME])?;
+    println!("User service stopped.");
     Ok(())
 }
 
@@ -242,6 +415,22 @@ async fn status() -> Result<()> {
     Ok(())
 }
 
+async fn status_user() -> Result<()> {
+    let output = Command::new("systemctl")
+        .args(["--user", "status", USER_UNIT_NAME])
+        .output()
+        .context("Failed to run systemctl --user status")?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !stdout.is_empty() {
+        println!("{}", stdout);
+    }
+    if !stderr.is_empty() {
+        eprintln!("{}", stderr);
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -257,4 +446,41 @@ fn run(cmd: &str, args: &[&str]) -> Result<()> {
         bail!("{cmd} {} failed: {}", args.join(" "), stderr.trim());
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_user_systemd_unit_without_token() {
+        let unit = render_user_systemd_unit(
+            Path::new("/home/deck/.local/share/rabbit_digger_pro/helper/rabbit-digger-pro"),
+            "127.0.0.1:9091",
+            None,
+        )
+        .unwrap();
+
+        assert!(unit.contains("WantedBy=default.target"));
+        assert!(unit.contains("RestartSec=3"));
+        assert!(unit.contains(
+            "ExecStart=/home/deck/.local/share/rabbit_digger_pro/helper/rabbit-digger-pro service run --bind 127.0.0.1:9091"
+        ));
+        assert!(!unit.contains("EnvironmentFile="));
+        assert!(!unit.contains("--access-token"));
+    }
+
+    #[test]
+    fn render_user_systemd_unit_with_env_file() {
+        let unit = render_user_systemd_unit(
+            Path::new("/home/deck/.local/share/rabbit_digger_pro/helper/rabbit-digger-pro"),
+            "127.0.0.1:9091",
+            Some(Path::new("/home/deck/.config/rabbit_digger_pro/helper.env")),
+        )
+        .unwrap();
+
+        assert!(unit.contains("EnvironmentFile=/home/deck/.config/rabbit_digger_pro/helper.env"));
+        assert!(!unit.contains("test-token"));
+        assert!(!unit.contains("--access-token"));
+    }
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -9,6 +9,8 @@ mod windows;
 
 use anyhow::{Context, Result};
 use clap::Parser;
+#[cfg(target_os = "linux")]
+use std::path::PathBuf;
 use std::process::Command;
 
 #[derive(Parser)]
@@ -22,21 +24,46 @@ pub enum ServiceAction {
         #[clap(long)]
         access_token: Option<String>,
     },
+    /// Install rdp as a user-level service and start it
+    #[cfg(target_os = "linux")]
+    InstallUser {
+        /// Bind address for the API/WebUI server
+        #[clap(long, default_value = "127.0.0.1:9091")]
+        bind: String,
+        /// Access token for API authentication
+        #[clap(long)]
+        access_token: Option<String>,
+        /// Binary to install. Defaults to the current executable.
+        #[clap(long)]
+        binary: Option<PathBuf>,
+    },
     /// Uninstall the system service
     Uninstall,
+    /// Uninstall the user-level service
+    #[cfg(target_os = "linux")]
+    UninstallUser,
     /// Start the installed service
     Start,
+    /// Start the installed user-level service
+    #[cfg(target_os = "linux")]
+    StartUser,
     /// Stop the installed service
     Stop,
+    /// Stop the installed user-level service
+    #[cfg(target_os = "linux")]
+    StopUser,
     /// Show service status
     Status,
+    /// Show user-level service status
+    #[cfg(target_os = "linux")]
+    StatusUser,
     /// Run in daemon mode (called by the service manager)
     Run {
         /// Bind address for the API/WebUI server
         #[clap(long, default_value = "127.0.0.1:9091")]
         bind: String,
         /// Access token for API authentication
-        #[clap(long)]
+        #[clap(long, env = "RD_ACCESS_TOKEN")]
         access_token: Option<String>,
     },
 }


### PR DESCRIPTION
## Summary
- Add Linux user-level service management for Steam Deck bootstrap/update without writing to `/usr/local/bin`.
- Add a Decky Loader plugin MVP with helper status, update checks, and an in-menu Update action backed by checksum-verified release manifests.
- Add Steam Deck bootstrap/release scripts plus a manual GitHub Actions workflow to build helper binary, Decky plugin zip, and update manifest.
- Add `scripts/install-steamdeck.sh uninstall` for cleanup, and make Decky Loader auto-install best-effort so Rabbit Digger Pro can still be staged when GitHub is unreachable from the Deck.

## Research Notes
- Followed the official Decky plugin template layout: `plugin.json`, `main.py`, `src/index.tsx`, `dist` output.
- Mirrored mature Decky patterns from AutoFlatpaks for QAM update status/notifications and Xray Decky for a proxy-oriented Decky control surface.
- Decky Loader itself may still need network access to GitHub; the bootstrap now stages our helper/plugin even when Decky cannot be installed yet.

## Verification
- `git diff --check`
- `cargo fmt -- --check`
- `cargo test -p rabbit-digger-pro`
- `cargo test --all` via pre-push hook
- `pnpm install --frozen-lockfile=false` in `packaging/decky/rabbit-digger-pro`
- `pnpm run build` in `packaging/decky/rabbit-digger-pro`
- `python3 -m py_compile packaging/decky/rabbit-digger-pro/main.py`
- `bash -n scripts/install-steamdeck.sh scripts/build-steamdeck-release.sh`
- `cargo zigbuild --target x86_64-unknown-linux-gnu --release --features webui_embed`
- Steam Deck install smoke with file manifest: `install-steamdeck.sh uninstall`, default `127.0.0.1:9091` install, `systemctl --user is-active rabbit-digger-pro.service`, and Web UI HTTP 200.
- Steam Deck token check: user service `ExecStart` no longer exposes `--access-token`; token env file is mode `600`.

## Notes
- The test Deck cannot currently reach GitHub directly, so Decky Loader auto-install is skipped/staged in that environment. Once Decky Loader is installed, the staged plugin directory is already in place.
- The test Deck had an older root/system `rabbit-digger-pro.service` occupying `127.0.0.1:9091`; it was stopped before validating the new user-level service path.
